### PR TITLE
Create Java6 bytecode for transdroid.jar

### DIFF
--- a/lib/build.xml
+++ b/lib/build.xml
@@ -15,6 +15,7 @@
   </target>
 
   <target name="transdroid.jar" depends="check-android-exists" >
+    <mkdir dir="build/" />
     <javac
 	srcdir="src/"
 	destdir="build/"


### PR DESCRIPTION
Android will only be able to create Dalvik bytecode if the input Java
bytecode is in Java6 format. Otherwise we get a bunch of
NoClassDefFoundError Exceptions along with "Could not find class X",
"Unable to resolve static method Y" and such errors for code in
transdroid.jar.

Helpful for #60.
