### PR TITLE
Fix speed parsing when units are unrecognized

### DIFF
--- a/lib/src/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
+++ b/lib/src/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
@@ -461,7 +461,7 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 		} else if (parts[1].equals("KiB/s")) {
 			return (int) (number * 1024);
 		}
-		return (int) (Double.parseDouble(parts[0]));
+		return (int) (Double.parseDouble(normalizeNumber(parts[0])));
 	}
 
 	private String normalizeNumber(String in) {


### PR DESCRIPTION
Hello,

When using QBitTorrent with a french locale, the units are not recognized by the QBittorrent adapter. Therefore a numberformat exception occurs when trying to translate a comma instead of a dot as a decimal separator.

Before improving on the unit recognition, adopting this small change might be great and certainly usable in other languages than French.
