### PR TITLE
Fix RTorrent magnet support

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
@@ -181,6 +181,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 
 				// Request to add a magnet link by URL
 				String magnet = ((AddByMagnetUrlTask) task).getUrl();
+				magnet = URLDecoder.decode(magnet, "UTF-8");
 				makeRtorrentCall("load_start", new String[] { magnet });
 				return new DaemonTaskSuccessResult(task);
 


### PR DESCRIPTION
RTorrent doesn't support application/x-www-form-urlencoded magnet links, like now send from Chrome.
