### PR TITLE
Fix always failing SSL with empty sslTrustKey

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/util/HttpHelper.java
+++ b/app/src/main/java/org/transdroid/daemon/util/HttpHelper.java
@@ -130,7 +130,7 @@ public class HttpHelper {
 		// Register http and https sockets
 		SchemeRegistry registry = new SchemeRegistry();
 		SocketFactory httpsSocketFactory;
-		if (sslTrustKey != null) {
+		if (sslTrustKey != null && sslTrustKey.length() != 0) {
 			httpsSocketFactory = new TlsSniSocketFactory(sslTrustKey);
 		} else if (sslTrustAll) {
 			httpsSocketFactory = new TlsSniSocketFactory(true);


### PR DESCRIPTION
Previously I had a self-signed certificate set up, and added the custom public key to the settings accordingly.
Now that I have acquired a real certificate, I could not get my server to work. After removing the server and re-adding the server, all did work.

I traced the problem to "ssl_trust_key" being "" (empty string) instead of null. When it is not null, it is treated like a custom key, even when it is empty. It is not possible to 'unset' the setting.

This PR should fix this issue. Unfortunately I was **not** able to setup a build environment to test it. Please review it carefully.