### PR TITLE
Support for qBittorrent 3.2.0

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
@@ -101,11 +101,9 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 		}
 		catch (DaemonException e) {
 			apiVersion = 1;
-			log.d(LOG_NAME, e.toString());
 		}
 		catch (NumberFormatException e) {
 			apiVersion = 1;
-			log.d(LOG_NAME, e.toString());
 		}
 
 		log.d(LOG_NAME, "qBittorrent API version is " + apiVersion);
@@ -162,15 +160,11 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 		// Have we already authenticated?  Check if we have the cookie that we need
 		List<Cookie> cookies = httpclient.getCookieStore().getCookies();
 		for (Cookie c : cookies) {
-			log.d(LOG_NAME, "Looking at this cookie: " + c.getName());
 			if (c.getName().equals("SID")) {
 				// And here it is!  Okay, no need authenticate again.
-				log.d(LOG_NAME, "We're already authed, no need to do it again.");
 				return;
 			}
 		}
-
-		log.d(LOG_NAME, "Authenticating...");
 
 		makeRequest(log, "/login", 
 				new BasicNameValuePair("username", settings.getUsername()),
@@ -180,10 +174,8 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 		// However, we would like to see if authentication was successful or not... 
 		cookies = httpclient.getCookieStore().getCookies();
 		for (Cookie c : cookies) {
-			log.d(LOG_NAME, "post auth looking at this cookie: " + c.getName());
 			if (c.getName().equals("SID")) {
 				// Good.  Let's get out of here.
-				log.d(LOG_NAME, "Authentication success!");
 				return;
 			}
 		}
@@ -609,9 +601,9 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 
 			long size;
 			if (apiVersion >= 2) {
-				size = parseSize(file.getString("size"));
-			} else {
 				size = file.getLong("size");
+			} else {
+				size = parseSize(file.getString("size"));
 			}
 
 			torrentfiles.add(new TorrentFile("" + i, file.getString("name"), null, null, size, (long) (size * file

--- a/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
@@ -193,11 +193,17 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 
 			switch (task.getMethod()) {
 			case Retrieve:
+				String path;
+				if (version >= 30200) {
+					path = "/query/torrents";
+				} else if (version >= 30000) {
+					path = "/json/torrents";
+				} else {
+					path = "/json/events";
+				}
 
 				// Request all torrents from server
-				JSONArray result = new JSONArray(makeRequest(log,
-					version >= 30200 ? "/query/torrents" :
-					version >= 30000 ? "/json/torrents" : "/json/events"));
+				JSONArray result = new JSONArray(makeRequest(log, path));
 				return new RetrieveTaskSuccessResult((RetrieveTask) task, parseJsonTorrents(result), null);
 
 			case GetTorrentDetails:


### PR DESCRIPTION
In qBittorrent 3.2.0, they changed around the API mildly, replacing a few paths, changing some numeric values passed as strings to be passed as numbers, and replacing the HTTP basic authentication with an API login request that provides a session cookie.

This patch, as far as I can tell/have tested, addresses all the relevant changes, and allows Transdroid to support both 3.2.0 along with any previously support versions (or at least 3.1.0, the one older version i tested against)