### PR TITLE
Add force recheck command for qBittorrent

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Daemon.java
+++ b/app/src/main/java/org/transdroid/daemon/Daemon.java
@@ -364,7 +364,7 @@ public enum Daemon {
 	}
 
 	public static boolean supportsForceRecheck(Daemon type) {
-		return type == uTorrent || type == BitTorrent || type == Deluge || type == rTorrent || type == Transmission || type == Dummy;
+		return type == uTorrent || type == BitTorrent || type == Deluge || type == rTorrent || type == Transmission || type == Dummy || type == qBittorrent;
 	}
 
 	public static boolean supportsExtraPassword(Daemon type) {

--- a/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
@@ -298,6 +298,11 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 					}
 					return new DaemonTaskSuccessResult(task);
 
+                case ForceRecheck:
+                    // Force recheck a torrent
+                    makeRequest(log, "/command/recheck", new BasicNameValuePair("hash", task.getTargetTorrent().getUniqueID()));
+                    return new DaemonTaskSuccessResult(task);
+
 				case SetTransferRates:
 
 					// TODO: This doesn't seem to work yet


### PR DESCRIPTION
Since qBitTorrent added support for force recheck through its web API, and I missed that feature in Transdroid, I thought I would add it.