### PR TITLE
Feature Request: The ability to save/queue torrents when the client application is down

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         }
     }
     lintOptions {
-        disable 'MissingTranslation', 'ExtraTranslation', 'StringFormatInvalid'
+        disable 'MissingTranslation', 'ExtraTranslation', 'StringFormatInvalid', 'ValidFragment'
     }
 }
 


### PR DESCRIPTION
Hi Erik,

I've had some instances where I've searched and located torrent files that I would like to download, but I cannot connect to my remote client.  Is there a way for transdroid to give me the option to 'store' the torrent until my client becomes available again?

Many thanks!
L