### PR TITLE
Fix stop/pause for rtorrent

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
@@ -135,7 +135,8 @@ public class RtorrentAdapter implements IDaemonAdapter {
 							"d.custom=seedingtime",
 							"d.custom1=",
 							"d.peers_complete=",
-							"d.peers_accounted=" });
+							"d.peers_accounted=",
+							"d.is_open=" });
 					// @formatter:on
 					return new RetrieveTaskSuccessResult((RetrieveTask) task, onTorrentsRetrieved(result),
 							lastKnownLabels);
@@ -456,7 +457,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 						i,
 						(String)info[0], // hash
 						(String)info[1], // name
-						convertTorrentStatus((Long)info[2], (Long)info[13], (Long)info[14], (Long)info[15]), // status
+						convertTorrentStatus((Long)info[2], (Long)info[24], (Long)info[13], (Long)info[14], (Long)info[15]), // status
 						basePath.substring(0, basePath.indexOf((String)info[17])), // locationDir
 						((Long)info[3]).intValue(), // rateDownload
 						((Long)info[4]).intValue(), // rateUpload
@@ -488,7 +489,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 						i,
 						(String)info[0], // hash
 						(String)info[1], // name
-						convertTorrentStatus(((Integer)info[2]).longValue(), ((Integer)info[13]).longValue(), ((Integer)info[14]).longValue(), ((Integer)info[15]).longValue()), // status
+						convertTorrentStatus(((Integer)info[2]).longValue(), ((Integer)info[24]).longValue(), ((Integer)info[13]).longValue(), ((Integer)info[14]).longValue(), ((Integer)info[15]).longValue()), // status
 						basePath.substring(0, basePath.indexOf((String)info[17])), // locationDir
 						rateDownload, // rateDownload
 						(Integer)info[4], // rateUpload
@@ -609,19 +610,24 @@ public class RtorrentAdapter implements IDaemonAdapter {
 		}
 	}
 
-	private TorrentStatus convertTorrentStatus(Long state, Long complete, Long active, Long checking) {
-		if (state == 0) {
-			return TorrentStatus.Queued;
-		} else if (active == 1) {
-			if (complete == 1) {
-				return TorrentStatus.Seeding;
-			} else {
-				return TorrentStatus.Downloading;
-			}
-		} else if (checking == 1) {
+	private TorrentStatus convertTorrentStatus(Long state, Long open, Long complete, Long active, Long checking) {
+		if (checking == 1) {
 			return TorrentStatus.Checking;
-		} else {
+		}
+
+		if (open == 1) {
+			// links with tracker/peers are open: not stopped
+			if (state == 1 && active == 1) {
+				if (complete == 1) {
+					return TorrentStatus.Seeding;
+				} else {
+					return TorrentStatus.Downloading;
+				}
+			}
 			return TorrentStatus.Paused;
+		} else {
+			// maybe could be Stopped or Waiting
+			return TorrentStatus.Queued;
 		}
 	}
 

--- a/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
@@ -226,49 +226,51 @@ public class RtorrentAdapter implements IDaemonAdapter {
 				case Pause:
 
 					// Pause a torrent
-					makeRtorrentCall(log, "d.pause", new String[]{task.getTargetTorrent().getUniqueID()});
+					makeRtorrentCall(log, "d.stop", new String[]{task.getTargetTorrent().getUniqueID()});
 					return new DaemonTaskSuccessResult(task);
 
 				case PauseAll:
 
 					// Resume all torrents
-					makeRtorrentCall(log, "d.multicall2", new String[]{"","main", "d.pause="});
+					makeRtorrentCall(log, "d.multicall2", new String[]{"","main", "d.stop="});
 					return new DaemonTaskSuccessResult(task);
 
 				case Resume:
 
 					// Resume a torrent
-					makeRtorrentCall(log, "d.resume", new String[]{task.getTargetTorrent().getUniqueID()});
+					makeRtorrentCall(log, "d.start", new String[]{task.getTargetTorrent().getUniqueID()});
 					return new DaemonTaskSuccessResult(task);
 
 				case ResumeAll:
 
 					// Resume all torrents
-					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.resume="});
+					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.start="});
 					return new DaemonTaskSuccessResult(task);
 
 				case Stop:
 
 					// Stop a torrent
 					makeRtorrentCall(log, "d.stop", new String[]{task.getTargetTorrent().getUniqueID()});
+					makeRtorrentCall(log, "d.close", new String[]{task.getTargetTorrent().getUniqueID()});
 					return new DaemonTaskSuccessResult(task);
 
 				case StopAll:
 
 					// Stop all torrents
-					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.stop="});
+					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.stop=", "d.close="});
 					return new DaemonTaskSuccessResult(task);
 
 				case Start:
 
 					// Start a torrent
+					makeRtorrentCall(log, "d.open", new String[]{task.getTargetTorrent().getUniqueID()});
 					makeRtorrentCall(log, "d.start", new String[]{task.getTargetTorrent().getUniqueID()});
 					return new DaemonTaskSuccessResult(task);
 
 				case StartAll:
 
 					// Start all torrents
-					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.start="});
+					makeRtorrentCall(log, "d.multicall2", new String[]{"", "main", "d.open=", "d.start="});
 					return new DaemonTaskSuccessResult(task);
 
 				case SetFilePriorities:


### PR DESCRIPTION
I noticed some discrepencies between `ruTorrent` and `transdroid` UI around `stop` and `pause` actions and states:

<h1> `stop` action resulted in torrents in `pause` state on `ruTorrent` </h1>

With this PR we now use the same xmlrpc commands as `ruTorrent` for `{pause,resume,stop,start}{,All}` (https://github.com/Novik/ruTorrent/blob/31a395ee6c9bc756d92c4c038ad229e1393ac1aa/plugins/httprpc/action.php#L243-L262)
I was however not able to test `StopAll` and `StartAll` as I haven't found any usage of them on the UI (`INTENT_STOPALL` and `INTENT_STARTALL` never set, only read).

<h1> Torrent Status computation needed update to keep in sync with actions copied from `ruTorrent` </h1>

- needed more information (`is_open`) to compute torrent status as in ruTorrent.
- there is no `stopped` status in `transdroid`, so I used `Queued` instead.

<h1> Details </h1>

<details> 
  <summary>My research notes</summary>

    * <2016-11-11 Fri> transdroid stop does pause instead
    ** transdroid rpc calls:
    https://github.com/erickok/transdroid/blob/531051adafdac197295fef3d02e8608e86585c13/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java#L215-L272
    *** stop: d.stop
    *** start: d.start
    *** pause: d.pause
    *** resume: d.resume
    *** remove: if including data {d.custom5.set=torrentid,1}; d.erase
    ** patched transdroid rpc calls:
    https://github.com/erickok/transdroid/blob/531051adafdac197295fef3d02e8608e86585c13/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java#L215-L272
    *** stop: d.stop, d.close
    *** start: d.open, d.start
    *** pause: d.stop
    *** resume: d.start
    *** remove: if including data {d.custom5.set=torrentid,1}; d.erase
    *** TODO xAll
    **** StopAll: "d.multicall2", new String[]{"", "main", "d.stop=", "d.close="}
    not used anywhere
    INTENT_STOPALL never set
    **** StartAll: "d.multicall2", new String[]{"", "main", "d.open=", "d.start="}
    not used anywhere
    INTENT_STARTALL never set
    **** DONE PauseAll: d.stop
         CLOSED: [2016-11-11 Fri 21:47]
    **** DONE ResumeAll: d.start
         CLOSED: [2016-11-11 Fri 21:47]
    *** DONE test pause/resume not using d.pause/d.resume
        CLOSED: [2016-11-12 Sat 20:00]
    **** DONE pause 
         CLOSED: [2016-11-11 Fri 18:00]
         - CLOSING NOTE [2016-11-11 Fri 18:00] \\
           displayed "paused" in transdroid + rutorrent
    **** TODO resume: KO
    *** MAYBE add d.delete_tied to remove
    ** rutorrent rpc calls calls:
    https://github.com/Novik/ruTorrent/blob/31a395ee6c9bc756d92c4c038ad229e1393ac1aa/plugins/httprpc/action.php#L243-L262
    *** stop: d.stop, d.close
    *** start: d.open, d.start
    *** pause: d.stop
    *** unpause: d.start
    *** remove: d.erase
    *** remove with data: d.set_custom5 torrentid {if forcedeletion: 2; else 1}; d.delete_tied; d.erase
    https://github.com/Novik/ruTorrent/blob/31a395ee6c9bc756d92c4c038ad229e1393ac1aa/plugins/erasedata/init.js#L41-L57
    ** rtorrent ui calls:
    https://github.com/rakshasa/rtorrent/blob/10ce6864b81aaf2a7e43e9959940696b47aac2bc/src/ui/element_download_list.cc#L66-L71
    *** ^d 0x04: stop if active; else remove: if active {d.stop} else {d.erase}
    *** ^s 0x13: start: d.start
    *** ^k 0x0B: stop and close: d.ignore_commands.set=1; d.stop; d.close
    *** no d.pause/d.resume/d.open call from ui
    ** rtorrent rpc server
    https://github.com/rakshasa/rtorrent/blob/c3f6db03841c0b1e5c71fd69a6b11cf8d8e3eaa5/src/command_download.cc#L691-L697
    *** d.stop: view.set_visible=stopped
    *** d.start: d.hashing_failed.set=0 ;view.set_visible=started
    *** d.pause: DownloadList::pause() which calls download.stop()
    *** d.resume: DownloadList::resume() which calls download.start()
    *** d.close: DownloadList::close_throw() which calls DownloadList::pause() + download.close()
    *** d.open: DownloadList::open_throw() which calls download.open()
    *** d.erase: core::DownloadList::erase_ptr(): WARNING not mapped on rpc server, different from ui::DownloadList which as no erase_ptr()
    from https://github.com/rakshasa/rtorrent/blob/10ce6864b81aaf2a7e43e9959940696b47aac2bc/src/command_download.cc#L696
    ** torrent status
    *** transdroid
    **** get infos
    retrieve
    https://github.com/erickok/transdroid/blob/531051adafdac197295fef3d02e8608e86585c13/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java#L110-L141
    call compute status
    https://github.com/erickok/transdroid/blob/531051adafdac197295fef3d02e8608e86585c13/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java#L457
    convertTorrentStatus((Long)info[2], (Long)info[13], (Long)info[14], (Long)info[15]), // status
    ***** 2: state
    ***** 13: complete
    is the torrent finished downloading?
    active + complete = seeding
    seeding not displayed on rutorrent view
    maybe different from is_done(): maybe one is for 100% downloaded, and the other for "all files that were requested are downloaded", just a guess
    ***** 14: is_active
    ***** 15: is_hash_checking
    **** compute status
    https://github.com/erickok/transdroid/blob/531051adafdac197295fef3d02e8608e86585c13/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java#L610-L624
    	private TorrentStatus convertTorrentStatus(Long state, Long complete, Long active, Long checking) {
    		if (state == 0) {
    			return TorrentStatus.Queued;
    		} else if (active == 1) {
    			if (complete == 1) {
    				return TorrentStatus.Seeding;
    			} else {
    				return TorrentStatus.Downloading;
    			}
    		} else if (checking == 1) {
    			return TorrentStatus.Checking;
    		} else {
    			return TorrentStatus.Paused;
    		}
    	}
    ***** TODO waiting
    ***** WONTDO error
          CLOSED: [2016-11-11 Fri 20:42]
          - CLOSING NOTE [2016-11-11 Fri 20:42] \\
            already handled in the Torrent constructor
    *** rutorrent
    **** get infos
    list
    https://github.com/Novik/ruTorrent/blob/31a395ee6c9bc756d92c4c038ad229e1393ac1aa/plugins/httprpc/action.php#L90-L99
    			"d.get_hash=", "d.is_open=", "d.is_hash_checking=", "d.is_hash_checked=", "d.get_state=",
    			"d.get_name=", "d.get_size_bytes=", "d.get_completed_chunks=", "d.get_size_chunks=", "d.get_bytes_done=",
    			"d.get_up_total=", "d.get_ratio=", "d.get_up_rate=", "d.get_down_rate=", "d.get_chunk_size=",
    			"d.get_custom1=", "d.get_peers_accounted=", "d.get_peers_not_connected=", "d.get_peers_connected=", "d.get_peers_complete=",
    			"d.get_left_bytes=", "d.get_priority=", "d.get_state_changed=", "d.get_skip_total=", "d.get_hashing=",
    			"d.get_chunks_hashed=", "d.get_base_path=", "d.get_creation_date=", "d.get_tracker_focus=", "d.is_active=",
    			"d.get_message=", "d.get_custom2=", "d.get_free_diskspace=", "d.is_private=", "d.is_multi_file="
    ***** state
    https://github.com/rakshasa/rtorrent/blob/226e670decf92e7adaa845a6982aca4f164ea740/src/command_download.cc#L720-L723
      // 0 - stopped
      // 1 - started
      CMD2_DL_VAR_VALUE("d.state",      "rtorrent", "state");
      CMD2_DL_VAR_VALUE("d.complete",   "rtorrent", "complete");
    old names:
    get_state
    get_complete
    ***** is_open
    ***** is_active
    ***** is_hash_checking
    ***** get_hashing (renamed to hashing in 0.9)
    https://github.com/rakshasa/rtorrent/blob/226e670decf92e7adaa845a6982aca4f164ea740/src/command_download.cc#L733-L737
      // 0 - Not hashing
      // 1 - Normal hashing
      // 2 - Download finished, hashing
      // 3 - Rehashing
      CMD2_DL_VAR_VALUE("d.hashing", "rtorrent", "hashing");
    ****** not used in rutorrent display, just to disable some actions
    hashing != checking
    ***** more info
    https://github.com/rakshasa/rtorrent/blob/226e670decf92e7adaa845a6982aca4f164ea740/src/core/download.h#L79-L91
      bool                is_open() const                          { return m_download.info()->is_open(); }
      bool                is_active() const                        { return m_download.info()->is_active(); }
    # no available
      bool                is_done() const                          { return m_download.file_list()->is_done(); }
    
      bool                is_downloading() const                   { return is_active() && !is_done(); }
      bool                is_seeding() const                       { return is_active() && is_done(); }
    
      // FIXME: Fixed a bug in libtorrent that caused is_hash_checked to
      // return true when the torrent is closed. Remove this redundant
      // test in the next milestone.
      bool                is_hash_checked() const                  { return is_open() && m_download.is_hash_checked(); }
      bool                is_hash_checking() const                 { return m_download.is_hash_checking(); }
    
      bool                is_hash_failed() const                   { return m_hashFailed; }
    **** compute status
    var dStatus = { started : 1, paused : 2, checking : 4, hashing : 8, error : 16 };
    
    https://github.com/Novik/ruTorrent/blob/004555183075b35e020feff55e6426fd23eb7bf3/js/rtorrent.js#L996-L1016
    		if(is_open!=0)
    		{
    			state|=dStatus.started;
    			if((get_state==0) || (is_active==0))
    				state|=dStatus.paused;
    		}
    		if(get_hashing!=0)
    			state|=dStatus.hashing;
    		if(is_hash_checking!=0)
    			state|=dStatus.checking;
    		if(torrent.msg.length && torrent.msg!="Tracker: [Tried all trackers.]")
    			state|=dStatus.error;
    		torrent.state = state;

</details>

<h1> Remarks </h1>

- missing torrent state for finished (complete && stopped/inactive)
- missing stopped state when stopping/closing torrent without complete
currently have to return state Queued instead
- missing error display: it is passed to the Torrent constructor but Torrent.getError() never called
should we use TorrentState.Error?
- could not test stopall/startall: not used anywhere
don't know if multicall2 can take multiple commands or if we should use 2 calls to multicall2