### PR TITLE
Use "application/x-bittorrent" instead of "file/*" in File Picker

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/search/FilePickerHelper.java
+++ b/app/src/main/java/org/transdroid/core/gui/search/FilePickerHelper.java
@@ -42,7 +42,7 @@ public class FilePickerHelper {
 	public static void startFilePicker(final Activity activity) {
 		try {
 			// Start a file manager that can handle the file/* file/* intents
-			activity.startActivityForResult(new Intent(Intent.ACTION_GET_CONTENT).setType("file/*"),
+			activity.startActivityForResult(new Intent(Intent.ACTION_GET_CONTENT).setType("application/x-bittorrent"),
 					ACTIVITY_FILEPICKER);
 		} catch (Exception e1) {
 			try {


### PR DESCRIPTION
Fix for issue #405

Opening a native File Picker with MIME type "file/*" doesn't allow picking files - shows them as disabled.
Using "application/x-bittorrent" does work.