### PR TITLE
Fix bug when removing a server. 

### DIFF
--- a/app/src/main/java/org/transdroid/core/app/settings/ApplicationSettings.java
+++ b/app/src/main/java/org/transdroid/core/app/settings/ApplicationSettings.java
@@ -258,7 +258,7 @@ public class ApplicationSettings {
 			edit.remove("header_defaultserver");
 		} else if (defaultServer > order) {
 			// Move 'up' one place to account for the removed server setting
-			edit.putInt("header_defaultserver", --order);
+			edit.putString("header_defaultserver", String.valueOf(--order));
 		}
 
 		edit.apply();


### PR DESCRIPTION
header_defaultserver is a string everywhere else but here.