### PR TITLE
Improve Error Message For Deluge RPC Adapter

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/DetailsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/DetailsActivity.java
@@ -41,7 +41,6 @@ import org.transdroid.R;
 import org.transdroid.core.app.settings.ApplicationSettings;
 import org.transdroid.core.app.settings.ServerSetting;
 import org.transdroid.core.app.settings.SystemSettings_;
-import org.transdroid.core.gui.lists.LocalTorrent;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.navigation.Label;
 import org.transdroid.core.gui.navigation.NavigationHelper;
@@ -345,9 +344,9 @@ public class DetailsActivity extends AppCompatActivity implements TorrentTasksEx
 	@UiThread
 	protected void onCommunicationError(DaemonTaskFailureResult result, boolean isCritical) {
 		log.i(this, result.getException().toString());
-		String error = getString(LocalTorrent.getResourceForDaemonException(result.getException()));
+		String error = getString(result.getException().getErrorResourceId());
 		fragmentDetails.updateIsLoading(false, isCritical ? error : null);
-		SnackbarManager.show(Snackbar.with(this).text(getString(LocalTorrent.getResourceForDaemonException(result.getException())))
+		SnackbarManager.show(Snackbar.with(this).text(getString(result.getException().getErrorResourceId()))
 				.colorResource(R.color.red));
 	}
 

--- a/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
@@ -72,7 +72,6 @@ import org.transdroid.core.app.settings.ServerSetting;
 import org.transdroid.core.app.settings.SystemSettings;
 import org.transdroid.core.app.settings.SystemSettings_;
 import org.transdroid.core.app.settings.WebsearchSetting;
-import org.transdroid.core.gui.lists.LocalTorrent;
 import org.transdroid.core.gui.lists.SimpleListItem;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.log.LogUncaughtExceptionHandler;
@@ -1048,14 +1047,14 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
 		} catch (IllegalArgumentException e) {
 			// Illegal character or escape sequence; fail task to show error
 			onCommunicationError(new DaemonTaskFailureResult(AddByMagnetUrlTask.create(currentConnection, url),
-					new DaemonException(DaemonException.ExceptionType.FileAccessError, "Invalid characters in magnet link")), false);
+					new DaemonException(R.string.error_torrentfile, "Invalid characters in magnet link")), false);
 			return;
 		}
 
 		AddByMagnetUrlTask addByMagnetUrlTask = AddByMagnetUrlTask.create(currentConnection, url);
 		if (!Daemon.supportsAddByMagnetUrl(currentConnection.getType())) {
 			// No support for magnet links: forcefully let the task fail to report the error
-			onCommunicationError(new DaemonTaskFailureResult(addByMagnetUrlTask, new DaemonException(DaemonException.ExceptionType.MethodUnsupported,
+			onCommunicationError(new DaemonTaskFailureResult(addByMagnetUrlTask, new DaemonException(R.string.error_unsupported,
 					currentConnection.getType().name() + " does not support magnet links")), false);
 			return;
 		}
@@ -1323,7 +1322,7 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
 	protected void onCommunicationError(DaemonTaskFailureResult result, boolean isCritical) {
 		//noinspection ThrowableResultOfMethodCallIgnored
 		log.i(this, result.getException().toString());
-		String error = getString(LocalTorrent.getResourceForDaemonException(result.getException()));
+		String error = getString(result.getException().getErrorResourceId());
 		SnackbarManager.show(Snackbar.with(this).text(error).colorResource(R.color.red).type(SnackbarType.MULTI_LINE));
 		fragmentTorrents.updateIsLoading(false);
 		if (isCritical) {

--- a/app/src/main/java/org/transdroid/core/gui/lists/LocalTorrent.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/LocalTorrent.java
@@ -219,31 +219,4 @@ public class LocalTorrent {
 		return r.getString(abbreviate ? R.string.status_eta : R.string.status_etalong,
 				TimespanConverter.getTime(t.getEta(), inDays));
 	}
-
-	/**
-	 * Convert a DaemonException to a translatable human-readable error message
-	 * @param e The exception that was thrown by the server
-	 * @return A string resource ID to show to the user
-	 */
-	public static int getResourceForDaemonException(DaemonException e) {
-		switch (e.getType()) {
-		case MethodUnsupported:
-			return R.string.error_unsupported;
-		case ConnectionError:
-			return R.string.error_httperror;
-		case UnexpectedResponse:
-			return R.string.error_jsonresponseerror;
-		case ParsingFailed:
-			return R.string.error_jsonrequesterror;
-		case NotConnected:
-			return R.string.error_daemonnotconnected;
-		case AuthenticationFailure:
-			return R.string.error_401;
-		case FileAccessError:
-			return R.string.error_torrentfile;
-		default:
-			return R.string.error_httperror;
-		}
-	}
-
 }

--- a/app/src/main/java/org/transdroid/core/gui/remoterss/RemoteRssActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/remoterss/RemoteRssActivity.java
@@ -45,7 +45,6 @@ import org.transdroid.R;
 import org.transdroid.core.app.settings.ApplicationSettings;
 import org.transdroid.core.app.settings.ServerSetting;
 import org.transdroid.core.app.settings.SystemSettings_;
-import org.transdroid.core.gui.lists.LocalTorrent;
 import org.transdroid.core.gui.lists.SimpleListItemAdapter;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.navigation.RefreshableActivity;
@@ -184,7 +183,7 @@ public class RemoteRssActivity extends AppCompatActivity implements RefreshableA
 	protected void onCommunicationError(DaemonException daemonException) {
 		//noinspection ThrowableResultOfMethodCallIgnored
 		log.i(this, daemonException.toString());
-		String error = getString(LocalTorrent.getResourceForDaemonException(daemonException));
+		String error = getString(daemonException.getErrorResourceId());
 		SnackbarManager.show(Snackbar.with(this).text(error).colorResource(R.color.red).type(SnackbarType.MULTI_LINE));
 	}
 

--- a/app/src/main/java/org/transdroid/core/gui/remoterss/RemoteRssFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/remoterss/RemoteRssFragment.java
@@ -36,7 +36,6 @@ import org.androidannotations.annotations.ItemClick;
 import org.androidannotations.annotations.UiThread;
 import org.androidannotations.annotations.ViewById;
 import org.transdroid.R;
-import org.transdroid.core.gui.lists.LocalTorrent;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.navigation.RefreshableActivity;
 import org.transdroid.core.gui.remoterss.data.RemoteRssItem;
@@ -152,7 +151,7 @@ public class RemoteRssFragment extends Fragment {
 			supplier.downloadRemoteRssItem(log, item, activity.getChannel(item.getSourceName()));
 			onTaskSucceeded(null, getString(R.string.result_added, item.getTitle()));
 		} catch (DaemonException e) {
-			onTaskFailed(getString(LocalTorrent.getResourceForDaemonException(e)));
+			onTaskFailed(getString(e.getErrorResourceId()));
 		}
 	}
 

--- a/app/src/main/java/org/transdroid/core/gui/settings/ServerSettingsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/settings/ServerSettingsActivity.java
@@ -27,7 +27,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.PreferenceManager;
-import android.text.TextUtils;
 
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.OptionsItem;

--- a/app/src/main/java/org/transdroid/daemon/Aria2c/Aria2Adapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Aria2c/Aria2Adapter.java
@@ -29,10 +29,10 @@ import org.base64.android.Base64;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -220,17 +220,17 @@ public class Aria2Adapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (FileNotFoundException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		}
 	}
 
@@ -263,7 +263,7 @@ public class Aria2Adapter implements IDaemonAdapter {
 			return new JSONObject(raw);
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.UnexpectedResponse, e.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, e.toString());
 		}
 	}
 
@@ -273,7 +273,7 @@ public class Aria2Adapter implements IDaemonAdapter {
 			return new JSONArray(raw);
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.UnexpectedResponse, e.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, e.toString());
 		}
 	}
 
@@ -302,7 +302,7 @@ public class Aria2Adapter implements IDaemonAdapter {
 
 			HttpEntity entity = response.getEntity();
 			if (entity == null) {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity in response object.");
+				throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity in response object.");
 			}
 
 			// Read JSON response
@@ -317,7 +317,7 @@ public class Aria2Adapter implements IDaemonAdapter {
 
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/BitComet/BitCometAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/BitComet/BitCometAdapter.java
@@ -32,10 +32,10 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HTTP;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -237,11 +237,11 @@ public class BitCometAdapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (DaemonException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		}
 	}
 
@@ -297,13 +297,13 @@ public class BitCometAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (UnsupportedEncodingException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -356,10 +356,10 @@ public class BitCometAdapter implements IDaemonAdapter {
 			return false;
 
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, e.toString());
+			throw new DaemonException(R.string.error_torrentfile, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 	}
 
@@ -415,7 +415,7 @@ public class BitCometAdapter implements IDaemonAdapter {
 			return false;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 	}
 
@@ -535,7 +535,7 @@ public class BitCometAdapter implements IDaemonAdapter {
 				}
 			}
 		} catch (Exception e) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "Invalid BitComet HTTP response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "Invalid BitComet HTTP response.");
 		}
 
 		return torrents;
@@ -677,9 +677,9 @@ public class BitCometAdapter implements IDaemonAdapter {
 			}
 
 		} catch (XmlPullParserException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (Exception e) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "Invalid BitComet HTTP response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "Invalid BitComet HTTP response.");
 		}
 
 		return torrents;
@@ -724,7 +724,7 @@ public class BitCometAdapter implements IDaemonAdapter {
 				// @formatter:on
 			}
 		} catch (Exception e) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "Invalid BitComet HTTP response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "Invalid BitComet HTTP response.");
 		}
 
 		// Return the list

--- a/app/src/main/java/org/transdroid/daemon/Bitflu/BitfluAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Bitflu/BitfluAdapter.java
@@ -23,10 +23,10 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -121,16 +121,16 @@ public class BitfluAdapter implements IDaemonAdapter {
 					makeBitfluRequest(log, RPC_START_DOWNLOAD + magnet);
 					return new DaemonTaskSuccessResult(task);
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (UnsupportedEncodingException e) {
 			return new DaemonTaskFailureResult(task,
-					new DaemonException(ExceptionType.MethodUnsupported, e.toString()));
+					new DaemonException(R.string.error_unsupported, e.toString()));
 		}
 	}
 
@@ -155,7 +155,7 @@ public class BitfluAdapter implements IDaemonAdapter {
 			int httpstatus = response.getStatusLine().getStatusCode();
 
 			if (httpstatus != 200) {
-				throw new DaemonException(ExceptionType.UnexpectedResponse,
+				throw new DaemonException(R.string.error_jsonresponseerror,
 						"Invalid reply from server, http status code: " + httpstatus);
 			}
 
@@ -172,10 +172,10 @@ public class BitfluAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/BuffaloNas/BuffaloNasAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/BuffaloNas/BuffaloNasAdapter.java
@@ -32,10 +32,10 @@ import org.apache.http.message.BasicNameValuePair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -158,11 +158,11 @@ public class BuffaloNasAdapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		}
@@ -204,13 +204,13 @@ public class BuffaloNasAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (UnsupportedEncodingException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -235,10 +235,10 @@ public class BuffaloNasAdapter implements IDaemonAdapter {
 			return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
 
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, e.toString());
+			throw new DaemonException(R.string.error_torrentfile, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/DLinkRouterBT/DLinkRouterBTAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/DLinkRouterBT/DLinkRouterBTAdapter.java
@@ -28,10 +28,10 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -206,11 +206,11 @@ public class DLinkRouterBTAdapter implements IDaemonAdapter {
 				// return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		}
@@ -284,16 +284,16 @@ public class DLinkRouterBTAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (DaemonException e) {
 			throw e;
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.UnexpectedResponse, e.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/DaemonException.java
+++ b/app/src/main/java/org/transdroid/daemon/DaemonException.java
@@ -31,30 +31,14 @@ public class DaemonException extends Exception {
 
 	private static final long serialVersionUID = 1L;
 	
-	private ExceptionType internalException;
+	private int errorResourceId;
 
-	public enum ExceptionType {
-		MethodUnsupported,
-		ConnectionError,
-		UnexpectedResponse,
-		ParsingFailed,
-		AuthenticationFailure,
-		NotConnected,
-		FileAccessError;
-	}
-	
-	public DaemonException(ExceptionType internalException, String message) {
+	public DaemonException(int errorResourceId, String message) {
 		super(message);
-		this.internalException = internalException;
+		this.errorResourceId = errorResourceId;
 	}
 
-	public ExceptionType getType() {
-		return internalException;
+	public int getErrorResourceId() {
+		return errorResourceId;
 	}
-	
-	@Override
-	public String toString() {
-		return internalException.toString() + " exception: " + getMessage();
-	}
-
 }

--- a/app/src/main/java/org/transdroid/daemon/Deluge/DelugeAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Deluge/DelugeAdapter.java
@@ -32,10 +32,10 @@ import org.apache.http.protocol.HTTP;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
@@ -405,17 +405,17 @@ public class DelugeAdapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported, task.getMethod() + " is not " +
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported, task.getMethod() + " is not " +
 							"supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (FileNotFoundException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		}
 	}
 	
@@ -455,7 +455,7 @@ public class DelugeAdapter implements IDaemonAdapter {
 			// Continue though, ignoring the version number
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 		// Unable to establish version number; assume an old version by setting it to version 1
 		version = 10000;
@@ -517,7 +517,7 @@ public class DelugeAdapter implements IDaemonAdapter {
 				// Still no session cookie?
 				if (sessionCookie == null) {
 					// Set error message and cancel the action that was requested
-					throw new DaemonException(ExceptionType.AuthenticationFailure, "Password error? Server time difference? No (valid) cookie in " +
+					throw new DaemonException(R.string.error_401, "Password error? Server time difference? No (valid) cookie in " +
 							"response and JSON was: " + HttpHelper.convertStreamToString(instream));
 				}
 
@@ -563,14 +563,14 @@ public class DelugeAdapter implements IDaemonAdapter {
 			}
 
 			// No result?
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity in response object.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity in response object.");
 
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.UnexpectedResponse, e.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -601,7 +601,7 @@ public class DelugeAdapter implements IDaemonAdapter {
 		// Parse response
 		ArrayList<Torrent> torrents = new ArrayList<>();
 		if (response.isNull(RPC_TORRENTS)) {
-			throw new DaemonException(ExceptionType.NotConnected, "Web interface probably not connected to a daemon yet, because 'torrents' is null:" +
+			throw new DaemonException(R.string.error_daemonnotconnected, "Web interface probably not connected to a daemon yet, because 'torrents' is null:" +
 					" " + response.toString());
 		}
 		JSONObject objects = response.getJSONObject(RPC_TORRENTS);

--- a/app/src/main/java/org/transdroid/daemon/Deluge/DelugeRpcAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Deluge/DelugeRpcAdapter.java
@@ -20,6 +20,7 @@ package org.transdroid.daemon.Deluge;
 import android.support.annotation.NonNull;
 
 import org.base64.android.Base64;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.remoterss.data.RemoteRssChannel;
 import org.transdroid.core.gui.remoterss.data.RemoteRssItem;
@@ -29,7 +30,6 @@ import org.transdroid.core.rssparser.Item;
 import org.transdroid.core.rssparser.RssParser;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
@@ -197,7 +197,7 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
 				case ForceRecheck:
 					return doForceRecheck(client, (ForceRecheckTask) task);
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported, task.getMethod() + " is not " +
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported, task.getMethod() + " is not " +
                             "supported by " + getType()));
 			}
 		} catch (DaemonException e) {
@@ -225,7 +225,7 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
 			client.connect(settings);
 
 			if (!hasMethod(client, RPC_METHOD_GET_RSS_CONFIG)) {
-				throw new DaemonException(ExceptionType.MethodUnsupported, "YaRRS2 plugin not installed");
+				throw new DaemonException(R.string.error_unsupported, "YaRRS2 plugin not installed");
 			}
 			//noinspection unchecked
 			final Map<String, Object> rssConfig = (Map<String, Object>) client.sendRequest(RPC_METHOD_GET_RSS_CONFIG);
@@ -385,7 +385,7 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
 	@NonNull
 	private DaemonTaskResult doSetLabel(DelugeRpcClient client, SetLabelTask task) throws DaemonException {
 		if (!hasMethod(client, RPC_METHOD_SETLABEL)) {
-			throw new DaemonException(ExceptionType.MethodUnsupported, "Label plugin not installed");
+			throw new DaemonException(R.string.error_unsupported, "Label plugin not installed");
 		}
 		final String torrentId = task.getTargetTorrent().getUniqueID();
 		final String label = task.getNewLabel() == null ? "" : task.getNewLabel();
@@ -554,7 +554,7 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
 		try {
 			in = new BufferedInputStream(new FileInputStream(file));
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, "File not found: " + file.getAbsolutePath());
+			throw new DaemonException(R.string.error_torrentfile, "File not found: " + file.getAbsolutePath());
 		}
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();
 		try {
@@ -568,7 +568,7 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
 			}
 			return out.toByteArray();
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, "Error reading file: " + file.getAbsolutePath());
+			throw new DaemonException(R.string.error_torrentfile, "Error reading file: " + file.getAbsolutePath());
 		} finally {
 			try {
 				in.close();

--- a/app/src/main/java/org/transdroid/daemon/Deluge/DelugeRpcClient.java
+++ b/app/src/main/java/org/transdroid/daemon/Deluge/DelugeRpcClient.java
@@ -19,8 +19,8 @@ package org.transdroid.daemon.Deluge;
 
 import android.support.annotation.NonNull;
 
+import org.transdroid.R;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.util.TlsSniSocketFactory;
 
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+
 import se.dimovski.rencode.Rencode;
 
 import static org.transdroid.daemon.Deluge.DelugeCommon.RPC_METHOD_DAEMON_LOGIN;
@@ -49,6 +51,9 @@ class DelugeRpcClient implements Closeable {
 	private static final int RESPONSE_TYPE_INDEX = 0;
 	private static final int RESPONSE_RETURN_VALUE_INDEX = 2;
 	private static final int RPC_ERROR = 2;
+	private static final int RESPONSE_ERROR_TYPE_INDEX = 0;
+	private static final int RESPONSE_ERROR_MESSAGE_INDEX = 1;
+	public static final String ERROR_BAD_LOGIN = "BadLoginError";
 
 	private Socket socket;
 	private static AtomicInteger requestId = new AtomicInteger();
@@ -60,13 +65,15 @@ class DelugeRpcClient implements Closeable {
 				sendRequest(RPC_METHOD_DAEMON_LOGIN, settings.getUsername(), settings.getPassword());
 			}
 		} catch (NoSuchAlgorithmException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, "Failed to open socket: " + e.getMessage());
+			throw new DaemonException(R.string.error_httperror, "Failed to open socket: " + e.getMessage());
 		} catch (UnknownHostException e) {
-			throw new DaemonException(ExceptionType.AuthenticationFailure, "Failed to sign in: " + e.getMessage());
+			throw new DaemonException(R.string.error_httperror, "Failed to sign in: " + e.getMessage());
+		} catch (SSLPeerUnverifiedException e) {
+			throw new DaemonException(R.string.error_certificate_error, e.getMessage());
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, "Failed to open socket: " + e.getMessage());
+			throw new DaemonException(R.string.error_httperror, "Failed to open socket: " + e.getMessage());
 		} catch (KeyManagementException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, "Failed to open socket: " + e.getMessage());
+			throw new DaemonException(R.string.error_httperror, "Failed to open socket: " + e.getMessage());
 		}
 	}
 
@@ -85,13 +92,13 @@ class DelugeRpcClient implements Closeable {
 		try {
 			requestBytes = compress(Rencode.encode(new Object[]{new Object[]{requestId.getAndIncrement(), method, args, new HashMap<>()}}));
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, "Failed to encode request: " + e.getMessage());
+			throw new DaemonException(R.string.error_httperror, "Failed to encode request: " + e.getMessage());
 		}
 		try {
 			socket.getOutputStream().write(requestBytes);
 			return readResponse();
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.getMessage());
+			throw new DaemonException(R.string.error_httperror, e.getMessage());
 		}
 	}
 
@@ -127,31 +134,40 @@ class DelugeRpcClient implements Closeable {
 		final Object responseObject = Rencode.decode(bytes);
 
 		if (!(responseObject instanceof List)) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, responseObject.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, responseObject.toString());
 		}
 		final List response = (List) responseObject;
 
 		if (response.size() < RESPONSE_RETURN_VALUE_INDEX + 1) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, responseObject.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, responseObject.toString());
 		}
 
 		if (!(response.get(RESPONSE_TYPE_INDEX) instanceof Number)) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, responseObject.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, responseObject.toString());
 		}
 		final int type = ((Number) (response.get(RESPONSE_TYPE_INDEX))).intValue();
 
 		if (type == RPC_ERROR) {
-			throw new DaemonException(ExceptionType.UnexpectedResponse, responseObject.toString());
+			final List<String>  errorDetail = (List<String>) response.get(RESPONSE_RETURN_VALUE_INDEX);
+			final String errorType = errorDetail.get(RESPONSE_ERROR_TYPE_INDEX);
+			final String errorMessage = errorDetail.get(RESPONSE_ERROR_MESSAGE_INDEX);
+			final int errorResourceId;
+			if (ERROR_BAD_LOGIN.equals(errorType)) {
+				errorResourceId = R.string.error_401;
+			} else {
+				errorResourceId = R.string.error_jsonresponseerror;
+			}
+			throw new DaemonException(errorResourceId, errorMessage);
 		}
 
 		return response.get(2);
 	}
 
 	@NonNull
-	private Socket openSocket(DaemonSettings settings) throws NoSuchAlgorithmException, KeyManagementException, IOException {
+	private Socket openSocket(DaemonSettings settings) throws NoSuchAlgorithmException, KeyManagementException, IOException, DaemonException {
 		if (!settings.getSsl()) {
 			// Non-ssl connections
-			return new Socket(settings.getAddress(), settings.getPort());
+			throw new DaemonException(R.string.error_ssl_must_be_enabled, "Deluge RPC Adapter must have SSL enabled");
 		}
 		final TlsSniSocketFactory socketFactory;
 		if (settings.getSslTrustKey() != null && settings.getSslTrustKey().length() != 0) {

--- a/app/src/main/java/org/transdroid/daemon/DummyAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/DummyAdapter.java
@@ -17,16 +17,10 @@
  */
 package org.transdroid.daemon;
 
-import java.io.File;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Random;
+import android.net.Uri;
 
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -49,7 +43,13 @@ import org.transdroid.daemon.task.SetFilePriorityTask;
 import org.transdroid.daemon.task.SetLabelTask;
 import org.transdroid.daemon.task.SetTrackersTask;
 
-import android.net.Uri;
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
 
 /**
  * A dummy adapter that does not communicate with some server, but maintains a local list of dummy data (reset every
@@ -176,7 +176,7 @@ public class DummyAdapter implements IDaemonAdapter {
 				String url = ((AddByUrlTask) task).getUrl();
 				log.d(LOG_NAME, "Adding torrent " + url);
 				if (url == null || url.equals(""))
-					throw new DaemonException(DaemonException.ExceptionType.ParsingFailed, "No url specified");
+					throw new DaemonException(R.string.error_jsonrequesterror, "No url specified");
 				Uri uri = Uri.parse(url);
 				dummyTorrents.add(new Torrent(0, "torrent_byurl", uri.getLastPathSegment(), TorrentStatus.Queued,
 						"/downloads/" + uri.getLastPathSegment(), 0, 0, 0, 0, 0, 0, -1, 0, 0, 1024 * 1024 * 1000, 0,
@@ -292,7 +292,7 @@ public class DummyAdapter implements IDaemonAdapter {
 				return new DaemonTaskSuccessResult(task);
 				
 			default:
-				return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+				return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 						task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (DaemonException e) {

--- a/app/src/main/java/org/transdroid/daemon/Ktorrent/FileListParser.java
+++ b/app/src/main/java/org/transdroid/daemon/Ktorrent/FileListParser.java
@@ -1,17 +1,17 @@
 package org.transdroid.daemon.Ktorrent;
 
+import org.transdroid.R;
+import org.transdroid.daemon.DaemonException;
+import org.transdroid.daemon.Priority;
+import org.transdroid.daemon.TorrentFile;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.Priority;
-import org.transdroid.daemon.TorrentFile;
-import org.transdroid.daemon.DaemonException.ExceptionType;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 /**
  * A Ktorrent-specific parser for it's /data/torrent/files.xml output.
@@ -98,9 +98,9 @@ public class FileListParser {
 			return torrents;
 			
 		} catch (XmlPullParserException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 		
 	}

--- a/app/src/main/java/org/transdroid/daemon/Ktorrent/KtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Ktorrent/KtorrentAdapter.java
@@ -31,10 +31,10 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HttpContext;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -212,7 +212,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 					return null;
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (LoggedOutException e) {
@@ -226,7 +226,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 				return executeTask(log, task);
 			} else {
 				// Never retry more than twice; in this case just return a task failure
-				return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ConnectionError,
+				return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_httperror,
 						"Retried " + retries + " already, so we stopped now"));
 			}
 
@@ -266,7 +266,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -303,7 +303,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -320,7 +320,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			instream.close();
 			// Challenge string should be something like TncpX3TB8uZ0h8eqztZ6
 			if (challengeString.length() != 20) {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "No (valid) challenge string received");
+				throw new DaemonException(R.string.error_jsonresponseerror, "No (valid) challenge string received");
 			}
 
 			// Make login request
@@ -346,7 +346,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error during login: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -374,7 +374,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 				// This happens in particular when we were logged out (because somebody else logged into KTorrent's web interface)
 				throw new LoggedOutException();
 			} else {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "Action response was not OK but " + result);
+				throw new DaemonException(R.string.error_jsonresponseerror, "Action response was not OK but " + result);
 			}
 
 		} catch (LoggedOutException e) {
@@ -384,7 +384,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -428,7 +428,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 				// This happens in particular when we were logged out (because somebody else logged into KTorrent's web interface)
 				throw new LoggedOutException();
 			} else {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "Action response was not 1 but " + result);
+				throw new DaemonException(R.string.error_jsonresponseerror, "Action response was not 1 but " + result);
 			}
 
 		} catch (LoggedOutException e) {
@@ -438,7 +438,7 @@ public class KtorrentAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/Ktorrent/StatsParser.java
+++ b/app/src/main/java/org/transdroid/daemon/Ktorrent/StatsParser.java
@@ -1,18 +1,18 @@
 package org.transdroid.daemon.Ktorrent;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.List;
-
+import org.transdroid.R;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentStatus;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A Ktorrent-specific parser for it's /data/torrents.xml output.
@@ -155,9 +155,9 @@ public class StatsParser {
 			return torrents;
 			
 		} catch (XmlPullParserException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 		
 	}

--- a/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Qbittorrent/QbittorrentAdapter.java
@@ -33,10 +33,10 @@ import org.apache.http.protocol.HTTP;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
@@ -191,7 +191,7 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 		}
 
 		// No cookie found, we didn't authenticate.
-		throw new DaemonException(ExceptionType.AuthenticationFailure, "Server rejected our login");
+		throw new DaemonException(R.string.error_401, "Server rejected our login");
 	}
 
 	@Override
@@ -348,10 +348,10 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 
 				default:
 					return new DaemonTaskFailureResult(task,
-							new DaemonException(ExceptionType.MethodUnsupported, task.getMethod() + " is not supported by " + getType()));
+							new DaemonException(R.string.error_unsupported, task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		}
@@ -369,7 +369,7 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 			return makeWebRequest(httppost, log);
 
 		} catch (UnsupportedEncodingException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -386,7 +386,7 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 			return makeWebRequest(httppost, log);
 
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, e.toString());
+			throw new DaemonException(R.string.error_torrentfile, e.toString());
 		}
 
 	}
@@ -419,11 +419,11 @@ public class QbittorrentAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Rtorrent/RtorrentAdapter.java
@@ -19,10 +19,10 @@ package org.transdroid.daemon.Rtorrent;
 
 import android.text.TextUtils;
 
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
@@ -311,15 +311,15 @@ public class RtorrentAdapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (FileNotFoundException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ConnectionError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_httperror, e.toString()));
 		}
 	}
 
@@ -342,12 +342,12 @@ public class RtorrentAdapter implements IDaemonAdapter {
 		} catch (XMLRPCException e) {
 			log.d(LOG_NAME, e.toString());
 			if (e.getCause() instanceof UnauthorizdException) {
-				throw new DaemonException(ExceptionType.AuthenticationFailure, e.toString());
+				throw new DaemonException(R.string.error_401, e.toString());
 			}
 			if (e.getCause() instanceof DaemonException) {
 				throw (DaemonException) e.getCause();
 			}
-			throw new DaemonException(ExceptionType.ConnectionError,
+			throw new DaemonException(R.string.error_httperror,
 					"Error making call to " + serverMethod + " with params [" +
 							(params.length() > 100 ? params.substring(0, 100) + "..." : params) + " ]: " +
 							e.toString());
@@ -382,7 +382,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 
 		if (response == null || !(response instanceof Object[])) {
 
-			throw new DaemonException(ExceptionType.ParsingFailed,
+			throw new DaemonException(R.string.error_jsonrequesterror,
 					"Response on retrieveing torrents did not return a list of objects");
 
 		} else {
@@ -528,7 +528,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 
 		if (response == null || !(response instanceof Object[])) {
 
-			throw new DaemonException(ExceptionType.ParsingFailed,
+			throw new DaemonException(R.string.error_jsonrequesterror,
 					"Response on retrieveing torrent files did not return a list of objects");
 
 		} else {
@@ -635,7 +635,7 @@ public class RtorrentAdapter implements IDaemonAdapter {
 
 		if (response == null || !(response instanceof Object[])) {
 
-			throw new DaemonException(ExceptionType.ParsingFailed,
+			throw new DaemonException(R.string.error_jsonrequesterror,
 					"Response on retrieveing trackers did not return a list of objects");
 
 		} else {

--- a/app/src/main/java/org/transdroid/daemon/Synology/SynologyAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Synology/SynologyAdapter.java
@@ -30,10 +30,10 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -167,7 +167,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 					.get("&method=login&account=" + settings.getUsername() + "&passwd=" + settings.getPassword() +
 							"&session=DownloadStation&format=sid").getData(log).getString("sid");
 		} catch (JSONException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		}
 	}
 
@@ -183,7 +183,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 					"&method=create&uri=" + URLEncoder.encode(uri, "UTF-8")).ensureSuccess(log);
 		} catch (UnsupportedEncodingException e) {
 			// Never happens
-			throw new DaemonException(ExceptionType.UnexpectedResponse, e.toString());
+			throw new DaemonException(R.string.error_jsonresponseerror, e.toString());
 		}
 	}
 
@@ -194,7 +194,7 @@ public class SynologyAdapter implements IDaemonAdapter {
           new FilePart("file", file))
 					.ensureSuccess(log);
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, e.getMessage());
+			throw new DaemonException(R.string.error_torrentfile, e.getMessage());
 		}
 	}
 
@@ -258,7 +258,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 			}
 			return result;
 		} catch (JSONException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		}
 	}
 
@@ -290,7 +290,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 			}
 			return result;
 		} catch (JSONException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		}
 	}
 
@@ -315,7 +315,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 			}
 			return new TorrentDetails(trackers, errors);
 		} catch (JSONException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		}
 	}
 
@@ -450,10 +450,10 @@ public class SynologyAdapter implements IDaemonAdapter {
 					return json.getJSONObject("data");
 				} else {
 					log.e(LOG_NAME, "not a success: " + json.toString());
-					throw new DaemonException(ExceptionType.AuthenticationFailure, json.getString("error"));
+					throw new DaemonException(R.string.error_401, json.getString("error"));
 				}
 			} catch (JSONException e) {
-				throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+				throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 			}
 		}
 
@@ -462,7 +462,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 				HttpEntity entity = response.getEntity();
 				if (entity == null) {
 					log.e(LOG_NAME, "Error: No entity in HTTP response");
-					throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+					throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 				}
 				// Read JSON response
 				java.io.InputStream instream = entity.getContent();
@@ -472,10 +472,10 @@ public class SynologyAdapter implements IDaemonAdapter {
 				instream.close();
 				return json;
 			} catch (JSONException e) {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "Bad JSON");
+				throw new DaemonException(R.string.error_jsonresponseerror, "Bad JSON");
 			} catch (IOException e) {
 				log.e(LOG_NAME, "getJson error: " + e.toString());
-				throw new DaemonException(ExceptionType.AuthenticationFailure, e.toString());
+				throw new DaemonException(R.string.error_401, e.toString());
 			}
 		}
 
@@ -483,10 +483,10 @@ public class SynologyAdapter implements IDaemonAdapter {
 			JSONObject json = getJson(log);
 			try {
 				if (!json.getBoolean("success")) {
-					throw new DaemonException(ExceptionType.UnexpectedResponse, json.getString("error"));
+					throw new DaemonException(R.string.error_jsonresponseerror, json.getString("error"));
 				}
 			} catch (JSONException e) {
-				throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+				throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 			}
 		}
 
@@ -507,7 +507,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 			try {
 				return new SynoResponse(getHttpClient().execute(new HttpGet(buildURL(params))));
 			} catch (IOException e) {
-				throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+				throw new DaemonException(R.string.error_httperror, e.toString());
 			}
 		}
 
@@ -528,7 +528,7 @@ public class SynologyAdapter implements IDaemonAdapter {
 				request.setEntity(new MultipartEntity(allParams));
 				return new SynoResponse(getHttpClient().execute(request));
 			} catch (IOException e) {
-				throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+				throw new DaemonException(R.string.error_httperror, e.toString());
 			}
 		}
 

--- a/app/src/main/java/org/transdroid/daemon/Tfb4rt/StatsParser.java
+++ b/app/src/main/java/org/transdroid/daemon/Tfb4rt/StatsParser.java
@@ -1,18 +1,18 @@
 package org.transdroid.daemon.Tfb4rt;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.List;
-
+import org.transdroid.R;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentStatus;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A Torrentflux-b4rt-specific parser for it's stats.xml output.
@@ -48,11 +48,11 @@ public class StatsParser {
 			String name = xpp.getName();
 			if (name.equals("html")) {
 				// We are given an html page instead of xml data; probably an authentication error
-				throw new DaemonException(DaemonException.ExceptionType.AuthenticationFailure, "HTML tag found instead of XML data; authentication error?");
+				throw new DaemonException(R.string.error_401, "HTML tag found instead of XML data; authentication error?");
 			}
 			if (name.equals("rss")) {
 				// We are given an html page instead of xml data; probably an authentication error
-				throw new DaemonException(DaemonException.ExceptionType.UnexpectedResponse, "RSS feed found instead of XML data; configuration error?");
+				throw new DaemonException(R.string.error_jsonresponseerror, "RSS feed found instead of XML data; configuration error?");
 			}
 			
 			while (next != XmlPullParser.END_DOCUMENT) {
@@ -122,7 +122,7 @@ public class StatsParser {
 								upSize = convertSize(xpp.getText());
 							}
 						} catch (Exception e) {
-							throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+							throw new DaemonException(R.string.error_httperror, e.toString());
 						}
 					}
 				}
@@ -137,9 +137,9 @@ public class StatsParser {
 			return torrents;
 			
 		} catch (XmlPullParserException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 		
 	}

--- a/app/src/main/java/org/transdroid/daemon/Tfb4rt/Tfb4rtAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Tfb4rt/Tfb4rtAdapter.java
@@ -17,26 +17,21 @@
  */
 package org.transdroid.daemon.Tfb4rt;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.math.BigInteger;
-import java.net.URI;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
+import com.android.internalcopy.http.multipart.FilePart;
+import com.android.internalcopy.http.multipart.MultipartEntity;
+import com.android.internalcopy.http.multipart.Part;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Torrent;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByUrlTask;
 import org.transdroid.daemon.task.DaemonTask;
@@ -47,9 +42,15 @@ import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
 import org.transdroid.daemon.util.HttpHelper;
-import com.android.internalcopy.http.multipart.FilePart;
-import com.android.internalcopy.http.multipart.MultipartEntity;
-import com.android.internalcopy.http.multipart.Part;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 /**
  * An adapter that allows for easy access to Torrentflux-b4rt installs. Communication is handled via HTTP GET requests
@@ -142,7 +143,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 				return null;
 
 			default:
-				return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+				return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 						task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (DaemonException e) {
@@ -174,7 +175,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -200,7 +201,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 			if (result.trim().equals("1")) {
 				return true;
 			} else {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "Action response was not 1 but " + result);
+				throw new DaemonException(R.string.error_jsonresponseerror, "Action response was not 1 but " + result);
 			}
 
 		} catch (DaemonException e) {
@@ -208,7 +209,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -237,7 +238,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 			if (result.equals("1")) {
 				return true;
 			} else {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "Action response was not 1 but " + result);
+				throw new DaemonException(R.string.error_jsonresponseerror, "Action response was not 1 but " + result);
 			}
 
 		} catch (DaemonException e) {
@@ -245,7 +246,7 @@ public class Tfb4rtAdapter implements IDaemonAdapter {
 			throw e;
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/Transmission/TransmissionAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Transmission/TransmissionAdapter.java
@@ -29,10 +29,10 @@ import org.base64.android.Base64.InputStream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -352,17 +352,17 @@ public class TransmissionAdapter implements IDaemonAdapter {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (FileNotFoundException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		}
 	}
 
@@ -431,7 +431,7 @@ public class TransmissionAdapter implements IDaemonAdapter {
 
 			// Authentication error?
 			if (response.getStatusLine().getStatusCode() == 401) {
-				throw new DaemonException(ExceptionType.AuthenticationFailure,
+				throw new DaemonException(R.string.error_401,
 						"401 HTTP response (username or password incorrect)");
 			}
 
@@ -465,16 +465,16 @@ public class TransmissionAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (DaemonException e) {
 			throw e;
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/Ttorrent/TtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Ttorrent/TtorrentAdapter.java
@@ -26,17 +26,16 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HTTP;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Priority;
@@ -59,14 +58,12 @@ import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
 import org.transdroid.daemon.task.SetFilePriorityTask;
-import org.transdroid.daemon.task.SetTransferRatesTask;
 import org.transdroid.daemon.util.HttpHelper;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -187,10 +184,10 @@ public class TtorrentAdapter implements IDaemonAdapter {
 
 				default:
 					return new DaemonTaskFailureResult(task,
-							new DaemonException(ExceptionType.MethodUnsupported, task.getMethod() + " is not supported by " + getType()));
+							new DaemonException(R.string.error_unsupported, task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		}
@@ -208,7 +205,7 @@ public class TtorrentAdapter implements IDaemonAdapter {
 			return makeWebRequest(httppost, log);
 
 		} catch (UnsupportedEncodingException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -225,7 +222,7 @@ public class TtorrentAdapter implements IDaemonAdapter {
 			return makeWebRequest(httppost, log);
 
 		} catch (FileNotFoundException e) {
-			throw new DaemonException(ExceptionType.FileAccessError, e.toString());
+			throw new DaemonException(R.string.error_torrentfile, e.toString());
 		}
 
 	}
@@ -255,11 +252,11 @@ public class TtorrentAdapter implements IDaemonAdapter {
 			}
 
 			log.d(LOG_NAME, "Error: No entity in HTTP response");
-			throw new DaemonException(ExceptionType.UnexpectedResponse, "No HTTP entity object in response.");
+			throw new DaemonException(R.string.error_jsonresponseerror, "No HTTP entity object in response.");
 
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}

--- a/app/src/main/java/org/transdroid/daemon/Utorrent/UtorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Utorrent/UtorrentAdapter.java
@@ -28,13 +28,13 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.core.gui.remoterss.data.RemoteRssChannel;
 import org.transdroid.core.gui.remoterss.data.RemoteRssItem;
 import org.transdroid.core.gui.remoterss.data.RemoteRssSupplier;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
@@ -176,7 +176,7 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 					// Request to add a torrent by URL
 					String url = ((AddByUrlTask) task).getUrl();
 					if (url == null || url.equals("")) {
-						throw new DaemonException(DaemonException.ExceptionType.ParsingFailed, "No url specified");
+						throw new DaemonException(R.string.error_jsonrequesterror, "No url specified");
 					}
 					makeUtorrentRequest(log, "&action=add-url&s=" + URLEncoder.encode(url, "UTF-8"));
 					return new DaemonTaskSuccessResult(task);
@@ -308,20 +308,20 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 					return new DaemonTaskSuccessResult(task);
 
 				default:
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported,
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported,
 							task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (JSONException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ParsingFailed, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_jsonrequesterror, e.toString()));
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (FileNotFoundException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 		} catch (UnsupportedEncodingException e) {
 			return new DaemonTaskFailureResult(task,
-					new DaemonException(ExceptionType.MethodUnsupported, e.toString()));
+					new DaemonException(R.string.error_unsupported, e.toString()));
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ConnectionError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_httperror, e.toString()));
 		}
 	}
 
@@ -390,7 +390,7 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 				if (retried < 2) {
 					return makeUtorrentRequest(log, addToUrl, ++retried);
 				}
-				throw new DaemonException(ExceptionType.AuthenticationFailure,
+				throw new DaemonException(R.string.error_401,
 						"Response was '" + result.replace("\n", "") +
 								"' instead of a proper JSON object (and we used auth token '" + authtoken + "')");
 			}
@@ -402,10 +402,10 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 			throw e;
 		} catch (JSONException e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		} catch (Exception e) {
 			log.d(LOG_NAME, "Error: " + e.toString());
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		}
 
 	}
@@ -422,11 +422,11 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 			// Parse the response HTML
 			HttpResponse response = httpclient.execute(httpget);
 			if (response.getStatusLine().getStatusCode() == 401) {
-				throw new DaemonException(ExceptionType.AuthenticationFailure,
+				throw new DaemonException(R.string.error_401,
 						"Auth denied (401) on token.html retrieval");
 			}
 			if (response.getStatusLine().getStatusCode() == 404) {
-				throw new DaemonException(ExceptionType.ConnectionError,
+				throw new DaemonException(R.string.error_httperror,
 						"Not found (404); server doesn't exist or is inaccessible");
 			}
 			InputStream instream = response.getEntity().getContent();
@@ -668,7 +668,7 @@ public class UtorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
 		try {
 			makeUtorrentRequest(log, "&action=add-url&s=" + URLEncoder.encode(link, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, "Invalid URL: " + link);
+			throw new DaemonException(R.string.error_jsonrequesterror, "Invalid URL: " + link);
 		}
 	}
 

--- a/app/src/main/java/org/transdroid/daemon/Vuze/VuzeAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/Vuze/VuzeAdapter.java
@@ -17,22 +17,11 @@
  */
 package org.transdroid.daemon.Vuze;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.openjpa.lib.util.Base16Encoder;
+import org.transdroid.R;
 import org.transdroid.core.gui.log.Log;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonMethod;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
@@ -53,6 +42,17 @@ import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
 import org.transdroid.daemon.task.SetFilePriorityTask;
 import org.transdroid.daemon.task.SetTransferRatesTask;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * An adapter that allows for easy access to Vuze torrent data. Communication
@@ -109,11 +109,11 @@ public class VuzeAdapter implements IDaemonAdapter {
 					in.read(bytes, 0, in.available());
 					in.close();
 				} catch (FileNotFoundException e) {
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 				} catch (IllegalArgumentException e) {
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, "Invalid local URI"));
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, "Invalid local URI"));
 				} catch (Exception e) {
-					return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.FileAccessError, e.toString()));
+					return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_torrentfile, e.toString()));
 				} finally {
 					try {
 						if (in != null)
@@ -197,12 +197,12 @@ public class VuzeAdapter implements IDaemonAdapter {
 				return new DaemonTaskSuccessResult(task);
 				
 			default:
-				return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.MethodUnsupported, task.getMethod() + " is not supported by " + getType()));
+				return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_unsupported, task.getMethod() + " is not supported by " + getType()));
 			}
 		} catch (DaemonException e) {
 			return new DaemonTaskFailureResult(task, e);
 		} catch (IOException e) {
-			return new DaemonTaskFailureResult(task, new DaemonException(ExceptionType.ConnectionError, e.toString()));
+			return new DaemonTaskFailureResult(task, new DaemonException(R.string.error_httperror, e.toString()));
 		}
 	}
 
@@ -231,14 +231,14 @@ public class VuzeAdapter implements IDaemonAdapter {
 			initialise();
 		}
 		if (settings.getAddress() == null || settings.getAddress().equals("")) {
-			throw new DaemonException(DaemonException.ExceptionType.AuthenticationFailure, "No host name specified.");
+			throw new DaemonException(R.string.error_401, "No host name specified.");
 		}
 
 		if (savedConnectionID == null || savedPluginID == null) {
 			// Get plug-in interface (for connection and plug-in object IDs)
 			Map<String, Object> plugin = rpcclient.callXMLRPC(null, "getSingleton", null, null, false);
 			if (!plugin.containsKey("_connection_id")) {
-				throw new DaemonException(ExceptionType.UnexpectedResponse, "No connection ID returned on getSingleton request.");
+				throw new DaemonException(R.string.error_jsonresponseerror, "No connection ID returned on getSingleton request.");
 			}				
 			savedConnectionID = (Long) plugin.get("_connection_id");
 			savedPluginID = (Long) plugin.get("_object_id");
@@ -254,7 +254,7 @@ public class VuzeAdapter implements IDaemonAdapter {
 					// Plugin config needed, but we don't know it's ID yet
 					Map<String, Object> config = rpcclient.callXMLRPC(savedPluginID, "getPluginconfig", null, savedConnectionID, false);
 					if (!config.containsKey("_object_id")) {
-						throw new DaemonException(ExceptionType.UnexpectedResponse, "No plugin config ID returned on getPluginconfig");
+						throw new DaemonException(R.string.error_jsonresponseerror, "No plugin config ID returned on getPluginconfig");
 					}				
 					savedPluginConfigID = (Long) config.get("_object_id");
 					vuzeObjectID = savedPluginConfigID;
@@ -270,7 +270,7 @@ public class VuzeAdapter implements IDaemonAdapter {
 						// Download manager needed, but we don't know it's ID yet
 						Map<String, Object> manager = rpcclient.callXMLRPC(savedPluginID, "getTorrentManager", null, savedConnectionID, false);
 						if (!manager.containsKey("_object_id")) {
-							throw new DaemonException(ExceptionType.UnexpectedResponse, "No torrent manager ID returned on getTorrentManager");
+							throw new DaemonException(R.string.error_jsonresponseerror, "No torrent manager ID returned on getTorrentManager");
 						}				
 						savedTorrentManagerID = (Long) manager.get("_object_id");
 						vuzeObjectID = savedTorrentManagerID;
@@ -283,7 +283,7 @@ public class VuzeAdapter implements IDaemonAdapter {
 						// Download manager needed, but we don't know it's ID yet
 						Map<String, Object> manager = rpcclient.callXMLRPC(savedPluginID, "getDownloadManager", null, savedConnectionID, false);
 						if (!manager.containsKey("_object_id")) {
-							throw new DaemonException(ExceptionType.UnexpectedResponse, "No download manager ID returned on getDownloadManager");
+							throw new DaemonException(R.string.error_jsonresponseerror, "No download manager ID returned on getDownloadManager");
 						}
 						savedDownloadManagerID = (Long) manager.get("_object_id");
 					}
@@ -295,7 +295,7 @@ public class VuzeAdapter implements IDaemonAdapter {
 					// Download manager needed, but we don't know it's ID yet
 					Map<String, Object> manager = rpcclient.callXMLRPC(savedPluginID, "getDownloadManager", null, savedConnectionID, false);
 					if (!manager.containsKey("_object_id")) {
-						throw new DaemonException(ExceptionType.UnexpectedResponse, "No download manager ID returned on getDownloadManager");
+						throw new DaemonException(R.string.error_jsonresponseerror, "No download manager ID returned on getDownloadManager");
 					}
 					savedDownloadManagerID = (Long) manager.get("_object_id");
 					vuzeObjectID = savedDownloadManagerID;
@@ -381,7 +381,7 @@ public class VuzeAdapter implements IDaemonAdapter {
 			Map<String, Object> info = (Map<String, Object>) response.get(key);
 			if (info == null || !info.containsKey("_object_id") || info.get("_object_id") == null) {
 				// No valid XML data object returned
-				throw new DaemonException(DaemonException.ExceptionType.UnexpectedResponse, "Map of objects returned by Vuze, but these object do not have some <info> attached or no <_object_id> is available");
+				throw new DaemonException(R.string.error_jsonresponseerror, "Map of objects returned by Vuze, but these object do not have some <info> attached or no <_object_id> is available");
 			}
 			Map<String, Object> torrentinfo = (Map<String, Object>) info.get("torrent");
 			Map<String, Object> statsinfo = (Map<String, Object>) info.get("stats");

--- a/app/src/main/java/org/transdroid/daemon/Vuze/VuzeXmlOverHttpClient.java
+++ b/app/src/main/java/org/transdroid/daemon/Vuze/VuzeXmlOverHttpClient.java
@@ -17,14 +17,7 @@
  */
  package org.transdroid.daemon.Vuze;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
+import android.util.Xml;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -36,7 +29,6 @@ import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.scheme.SocketFactory;
-import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
@@ -44,16 +36,23 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 import org.base64.android.Base64;
+import org.transdroid.R;
 import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.DaemonSettings;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.util.TlsSniSocketFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
-import android.util.Xml;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * Implements an XML-RPC-like client that build and parses XML following 
@@ -128,7 +127,7 @@ public class VuzeXmlOverHttpClient {
         client = new DefaultHttpClient(new ThreadSafeClientConnManager(httpParams, registry), httpParams);
         if (settings.shouldUseAuthentication()) {
             if (settings.getUsername() == null || settings.getPassword() == null) {
-                    throw new DaemonException(DaemonException.ExceptionType.AuthenticationFailure, "No username or password set, while authentication was enabled.");
+                    throw new DaemonException(R.string.error_401, "No username or password set, while authentication was enabled.");
             } else {
             	username = settings.getUsername();
             	password = settings.getPassword();
@@ -215,9 +214,9 @@ public class VuzeXmlOverHttpClient {
 			// check status code
 			int statusCode = response.getStatusLine().getStatusCode();
 			if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
-				throw new DaemonException(ExceptionType.AuthenticationFailure, "HTTP " + HttpStatus.SC_UNAUTHORIZED + " response (so no user or password or incorrect ones)");
+				throw new DaemonException(R.string.error_401, "HTTP " + HttpStatus.SC_UNAUTHORIZED + " response (so no user or password or incorrect ones)");
 			} else if (statusCode != HttpStatus.SC_OK) {
-				throw new DaemonException(ExceptionType.ConnectionError, "HTTP status code: " + statusCode + " != " + HttpStatus.SC_OK);
+				throw new DaemonException(R.string.error_httperror, "HTTP status code: " + statusCode + " != " + HttpStatus.SC_OK);
 			}
 
 			// parse response stuff
@@ -248,7 +247,7 @@ public class VuzeXmlOverHttpClient {
 				// Error
 				String errorText = pullParser.nextText(); // the value of the ERROR
 				entity.consumeContent();
-				throw new DaemonException(ExceptionType.ConnectionError, errorText);
+				throw new DaemonException(R.string.error_httperror, errorText);
 				
 			} else {
 				
@@ -272,9 +271,9 @@ public class VuzeXmlOverHttpClient {
 			}
 			
 		} catch (IOException e) {
-			throw new DaemonException(ExceptionType.ConnectionError, e.toString());
+			throw new DaemonException(R.string.error_httperror, e.toString());
 		} catch (XmlPullParserException e) {
-			throw new DaemonException(ExceptionType.ParsingFailed, e.toString());
+			throw new DaemonException(R.string.error_jsonrequesterror, e.toString());
 		}
 	}
 

--- a/app/src/main/java/org/transdroid/daemon/util/HttpHelper.java
+++ b/app/src/main/java/org/transdroid/daemon/util/HttpHelper.java
@@ -41,8 +41,8 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 import org.apache.http.protocol.HttpContext;
+import org.transdroid.R;
 import org.transdroid.daemon.DaemonException;
-import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 
 import java.io.BufferedReader;
@@ -154,7 +154,7 @@ public class HttpHelper {
 		// Authentication credentials
 		if (userBasicAuth) {
 			if (username == null || password == null) {
-				throw new DaemonException(ExceptionType.AuthenticationFailure,
+				throw new DaemonException(R.string.error_401,
 						"No username or password was provided while we had authentication enabled");
 			}
 			httpclient.getCredentialsProvider()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,7 +476,9 @@
 	<string name="error_notalabel">Please enter a valid label or pick from the list</string>
 	<string name="error_stillloadingdetails">Please wait until the torrent details have been loaded</string>
 	<string name="error_noftpapp">No app found that can download %1$s</string>
-	
+	<string name="error_ssl_must_be_enabled">This server type only supports SSL connections. Please enable SSL in Advanced Server Settings.</string>
+	<string name="error_certificate_error">Please enable "Accept all SSL certificates" or provide a SHA-1 thumbprint in Advanced Server Settings.</string>
+
 	<string name="update_app_newversion">New Transdroid version available</string>
 	<string name="update_search_newversion">New Transdroid search module available</string>
 	<string name="update_updateto">You can now update to %1$s</string>


### PR DESCRIPTION
This provides better error messages specifically when SSL configuration is wrong.

I also made a change to DeamonException:
Instead of having a list of error types, I changed it to accept a string resources.
This allows different adapters to report errors that might be unique to their implementation without poluting the DeamonException class with types that are not relevant to anyone else.