### PR TITLE
Fix AndFTP files download

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/DetailsFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/DetailsFragment.java
@@ -550,6 +550,14 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
 				if (urlBase == null || urlBase.equals("")) {
 					urlBase = "ftp://" + currentServerSettings.getAddress() + "/";
 				}
+				String rootDir = "";
+				if (urlBase.matches("(ftps?|scp|sftp)://.+/.+")) {
+					String[] split = urlBase.split("/", 4);
+					rootDir = "/" + split[3];
+					if (!rootDir.endsWith("/")) {
+						rootDir = rootDir + "/";
+					}
+				}
 
 				// Try using AndFTP intents
 				Intent andftpStart = new Intent(Intent.ACTION_PICK);
@@ -578,7 +586,7 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
 						if (file.startsWith("/") && file.indexOf("/", 1) < 0) {
 							file = file.substring(1);
 						}
-						andftpStart.putExtra("remote_file" + (f + 1), file);
+						andftpStart.putExtra("remote_file" + (f + 1), rootDir + file);
 					}
 				}
 				if (andftpStart.resolveActivity(getActivity().getPackageManager()) != null) {


### PR DESCRIPTION
AndFTP does not seem to follow the (S)FTP directory path if written at the end of ftp(s):// or sftp:// links.
That's why I made this PR to add (S)FTP directory path to "remote_file" automatically.