### PR TITLE
Fix build errors due to AndroidAnnotations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
             annotationProcessorOptions {
                 arguments = [
                         "resourcePackageName": "org.transdroid",
-                        "androidManifestFile": "app/src/main/AndroidManifest.xml"
+                        "androidManifestFile": file("src/main/AndroidManifest.xml").absolutePath
                 ]
             }
         }


### PR DESCRIPTION
On Android Studio 3.6.1, AA was not finding the manifest file. This small change helped, coupled with #530.