### PR TITLE
fixed mimic label not working

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
@@ -144,7 +144,6 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
 	 * @param newTorrents The new, updated list of torrents
 	 */
 	public void updateTorrents(ArrayList<Torrent> newTorrents, ArrayList<Label> currentLabels) {
-		if (!isResumed()) return;
 		torrents = newTorrents;
 		this.currentLabels = currentLabels;
 		applyAllFilters();
@@ -156,7 +155,6 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
 	 * @param wasRemoved Whether the affected torrent was indeed removed; otherwise it was updated somehow
 	 */
 	public void quickUpdateTorrent(Torrent affected, boolean wasRemoved) {
-		if (!isResumed()) return;
 		// Remove the old torrent object first
 		Iterator<Torrent> iter = torrents.iterator();
 		while (iter.hasNext()) {


### PR DESCRIPTION
isResumed() was always returning false upon activity resume, so torrent updates from details activity were not being applied

steps to reproduce bug:

* view unabelled torrents list
* click into torrent details
* set a label
* wait for success
* press back
* torrent still in the unlabelled list