### PR TITLE
fixed missing navigation labels after returning to TorrentsActivity

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
@@ -339,9 +339,13 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
 	protected void onResume() {
 		super.onResume();
 
+		// update navigation labels
+		navigationListAdapter.updateLabels(lastNavigationLabels);
+
 		// Refresh server settings
 		navigationListAdapter.updateServers(applicationSettings.getAllServerSettings());
 		ServerSetting lastUsed = applicationSettings.getLastUsedServer();
+
 		if (lastUsed == null) {
 			// Still no settings
 			updateFragmentVisibility(false);


### PR DESCRIPTION
bug: navigation list is missing labels

* load up TorrentsActivity
* click on a torrent to view details
* click back
* open up navigation menu, there are no labels

In case it's working, I've got "always destroy activities" turned on