### PR TITLE
Fix task id parsing for BitComet v1.68 and later

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/BitComet/BitCometAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/BitComet/BitCometAdapter.java
@@ -610,8 +610,6 @@ public class BitCometAdapter implements IDaemonAdapter {
 							settings.getType()));
 					// @formatter:on
 
-					id++; // Stop/start/etc. requests are made by ID, which is the order number in the returned XML list :-S
-
 				} else if (next == XmlPullParser.START_TAG && tagName.equals("task")) {
 
 					// Start of a new 'transfer' item; reset gathered torrent data
@@ -638,6 +636,8 @@ public class BitCometAdapter implements IDaemonAdapter {
 					if (next == XmlPullParser.TEXT) {
 						if (tagName.equals("name")) {
 							name = xpp.getText().trim();
+						} else if (tagName.equals("id")) {
+							id = Integer.parseInt(xpp.getText().trim());
 						} else if (tagName.equals("infohash")) {
 							hash = xpp.getText().trim();
 						} else if (tagName.equals("state")) {


### PR DESCRIPTION
The task id should be assigned from XML, not assumed to be the order number in the returned XML list.

The old code works only for BitComet v1.67 and earlier versions.
This fix is needed for BitComet v1.68 and later, and also compatible with old versions of BitComet.