### PR TITLE
Remove all whitespace from URL when adding

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/task/AddByMagnetUrlTask.java
+++ b/app/src/main/java/org/transdroid/daemon/task/AddByMagnetUrlTask.java
@@ -32,6 +32,6 @@ public class AddByMagnetUrlTask extends DaemonTask {
 		return new AddByMagnetUrlTask(adapter, data);
 	}
 	public String getUrl() {
-		return extras.getString("URL");
+		return extras.getString("URL").replaceAll("\\s", "");
 	}
 }

--- a/app/src/main/java/org/transdroid/daemon/task/AddByUrlTask.java
+++ b/app/src/main/java/org/transdroid/daemon/task/AddByUrlTask.java
@@ -33,7 +33,7 @@ public class AddByUrlTask extends DaemonTask {
 		return new AddByUrlTask(adapter, data);
 	}
 	public String getUrl() {
-		return extras.getString("URL");
+		return extras.getString("URL").replaceAll("\\s", "");
 	}
 	public String getTitle() {
 		return extras.getString("TITLE");


### PR DESCRIPTION
The use case is fairly specific. This allows copying and pasting URLs from a command line session where the URL wraps inside the terminal, which injects whitespace in the middle of the URL. Removing the whitespace manually is tedious. This handles it in the app.

Risk: Low