### PR TITLE
Remove trailing slash from folder in deluge adapter

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeAdapter.java
@@ -595,8 +595,15 @@ public class DelugeAdapter implements IDaemonAdapter {
      * @return The URL of the RPC API
      */
     private String buildWebUIUrl() {
-        return (settings.getSsl() ? "https://" : "http://") + settings.getAddress() + ":" + settings.getPort() + (settings.getFolder() == null ? ""
-                : settings.getFolder());
+        String folder = "";
+        if (settings.getFolder() != null) {
+            folder = settings.getFolder().trim();
+            // Strip any trailing slashes
+            if (folder.endsWith("/")) {
+                folder = folder.substring(0, folder.length() - 1);
+            }
+        }
+        return (settings.getSsl() ? "https://" : "http://") + settings.getAddress() + ":" + settings.getPort() + folder;
     }
 
     private ArrayList<Torrent> parseJsonRetrieveTorrents(JSONObject response) throws JSONException, DaemonException {


### PR DESCRIPTION
Fixes #583 

I put this MR in draft since I'm unable to check it locally right now.

Also, all adapters got different handling of this folder parameter (adding missing slash ahead, remove trailing slash, trimming), a better approach would be to add a common method for sanitizing this parameter (but `IDaemonAdapter` is an interface, not an abstract class...).