### PR TITLE
Fix rencode string length

### DIFF
--- a/app/src/main/java/se/dimovski/rencode/RencodeOutputStream.java
+++ b/app/src/main/java/se/dimovski/rencode/RencodeOutputStream.java
@@ -212,7 +212,7 @@ public class RencodeOutputStream extends FilterOutputStream implements DataOutpu
      * Writes a {@link String}
      */
     public void writeString(String value) throws IOException {
-        int len = value.length();
+        int len = value.getBytes().length;
         if (len < TypeCode.EMBEDDED.STR_COUNT) {
             write(TypeCode.EMBEDDED.STR_START + len);
         } else {


### PR DESCRIPTION
Problem:
Can not add magnet url to deluge through RPC interface
Root Cause:
The rencode string length is wrong if magnet URL contents CJK utf8 string
Solution:
Use byte length instead of string length