### PR TITLE
Remove obsolete pref_seedbox_xirviknofolder from translated files

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -283,7 +283,6 @@
     <string name="pref_seedbox_xirvikhint">Např.: eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Např.: semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Např.: desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Nelze načíst nastavení složky Xirvik SCGI; opakujte akci později nebo zkontrolujte nastavení adresy vašeho serveru</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minut</item>
         <item>30 minut</item>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -299,7 +299,6 @@
     <string name="pref_seedbox_xirvikhint">Eks. eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Eks. semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Eks. desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Kan ikke hente indstillingen for Xirvik SCGI; Prøv igen senere, eller ret din server adresseindstilling</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minutter</item>
         <item>30 minutter</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Like eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Like semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Like desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Die Xirvik SCGI-Ordner-Einstellung kann nicht abgerufen werden; Bitte versuchen Sie es später erneut, oder korrigieren Sie ihre Serveradresse</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 Minuten</item>
         <item>30 Minuten</item>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -304,7 +304,6 @@
     <string name="pref_seedbox_xirvikhint">مانند eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">مانند semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">مانند desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">نمی‌توان تنظیمات پوشه‌ی SCGIی Xirvik را دریافت کرد؛ لطفا ً بعدا ً دوباره امتحان کنید یا تنظیمات نشانی کارگزار را درست کنید</string>
     <string-array name="pref_notifyinterval_types">
         <item> 15 دقیقه </item>
         <item> 30 دقیقه </item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -299,7 +299,6 @@
     <string name="pref_seedbox_xirvikhint">Comme eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Comme semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Comme desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Impossible de récupérer le paramètre dossier de Xirvik SCGI ; Veuillez réessayer ultérieurement ou corriger le réglage d\'adresse de votre serveur</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minutes</item>
         <item>30 minutes</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Például eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Például semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Például desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Nem lehet letölteni a Xirvik SCGI mappa beállításait;  próbálja meg újra később, vagy javítsa ki a szerver címének beállításait</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 perc</item>
         <item>30 perc</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Esempio: eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Esempio: semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Esempio: desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Impossibile recuperare la cartella Xirvik SCGI; riprovare più tardi o correggere l\'indirizzo del server</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minuto</item>
         <item>30 minuto</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -307,7 +307,6 @@
     <string name="pref_seedbox_xirvikhint">eplus001.xirvik.com のように</string>
     <string name="pref_seedbox_xirvikhint2">semixl001a.xirvik.com のように</string>
     <string name="pref_seedbox_xirvikhint3">desharedgbit001.xirvik.com のように</string>
-    <string name="pref_seedbox_xirviknofolder">Xirvik SCGI フォルダー設定を読み取りできません。後で再度実行するか、サーバー･アドレス設定を確認してください</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 分</item>
         <item>30 分</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -307,7 +307,6 @@
     <string name="pref_seedbox_xirvikhint">예) eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">예) semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">예) desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Xirvik SCGI 폴더 설정을 받아오지 못했습니다; 다음에 다시 시도해 보시거나 서버 주소 설정을 고쳐보세요</string>
     <string-array name="pref_notifyinterval_types">
         <item>15분</item>
         <item>30분</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -311,7 +311,6 @@
     <string name="pref_seedbox_xirvikhint">Zoals eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Zoals semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Zoals desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Kan de Xirvik SCGI mount instelling niet laden; probeer later nog eens en controleer je serveradres</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minuten</item>
         <item>30 minuten</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Como eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Como semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Como desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Não foi possível recuperar a pasta de configuração do Xirvik SCGI; por favor, tente novamente mais tarde ou corrija a configuração de endereço do servidor</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minutos</item>
         <item>30 minutos</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Como eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Como semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Como desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Não é possível obter a configuração de pasta Xirvik SCGI; por favor, tente novamente mais tarde ou corrija a sua configuração de endereço do servidor</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minutos</item>
         <item>30 minutos</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -332,7 +332,6 @@
     <string name="pref_seedbox_xirvikhint">Как eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Как semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Как desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Не удается получить настройки папок Xirvik SCGI. Пожалуйста, повторите попытку позже или измените адрес сервера.</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 минут</item>
         <item>30 минут</item>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -331,7 +331,6 @@
     <string name="pref_seedbox_xirvikhint">Npr. eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Npr. semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Npr. desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Ne morem pridobiti Xirvik SCGI nastavitev map; poskusite pozneje ali popravite naslov strežnika</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minut</item>
         <item>30 minut</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -315,7 +315,6 @@
     <string name="pref_seedbox_xirvikhint">Som eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Som semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Som desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">Går inte att hämta Xirvik SCGI mappinställningen. Försök igen senare eller korrigera din serveradress</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 minuter</item>
         <item>30 minuter</item>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -314,7 +314,6 @@
     <string name="pref_seedbox_xirvikhint">eplus001.xirvik.com gibi</string>
     <string name="pref_seedbox_xirvikhint2">semixl001a.xirvik.com gibi</string>
     <string name="pref_seedbox_xirvikhint3">desharedgbit001.xirvik.com gibi</string>
-    <string name="pref_seedbox_xirviknofolder">Xirvik SCGI klasör ayarı alınamıyor; Lütfen daha sonra yeniden deneyin veya sunucu adresi ayarını doğrulayın</string>
     <string-array name="pref_notifyinterval_types">
         <item>15 dakika</item>
         <item>30 dakika</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -291,7 +291,6 @@
     <string name="pref_seedbox_xirvikhint">例如：eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">例如：semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">例如：desharedgbit001.xirvik.com</string>
-    <string name="pref_seedbox_xirviknofolder">无法检索Xirvik SCGI的文件夹设置，请稍后再试或更正您的服务器地址</string>
     <string-array name="pref_notifyinterval_types">
         <item>每15分钟</item>
         <item>每30分钟</item>


### PR DESCRIPTION
Seems like `pref_seedbox_xirviknofolder` was removed in favor of `pref_seedbox_xirvikfolderfallback` in https://github.com/erickok/transdroid/commit/29c3b3b0dc71f568e1b17f1d953f4d452736bece but the translated copies of `pref_seedbox_xirviknofolder` were not removed.
