### PR TITLE
Remove illegal character from BitCometAdapter.java

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/bitComet/BitCometAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/bitComet/BitCometAdapter.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *	This file is part of Transdroid <http://www.transdroid.org>
  *
  *	Transdroid is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Remove unprintable char from `BitCometAdapter.java` .

Fixes https://github.com/erickok/transdroid/issues/627

