### PR TITLE
BitComet: Update to use add magnet url for passed links

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/bitComet/BitCometAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/bitComet/BitCometAdapter.java
@@ -163,14 +163,14 @@ public class BitCometAdapter implements IDaemonAdapter {
 
                     // Request to add a torrent by URL
                     String url = ((AddByUrlTask) task).getUrl();
-                    makeUploadUrlRequest(log, "/panel/task_add_httpftp_result", url);
+                    makeUploadUrlRequest(log, "/panel/task_add_magnet_result", url);
                     return new DaemonTaskSuccessResult(task);
 
                 case AddByMagnetUrl:
 
                     // Request to add a torrent by URL
                     String magnetUrl = ((AddByMagnetUrlTask) task).getUrl();
-                    makeUploadUrlRequest(log, "/panel/task_add_httpftp_result", magnetUrl);
+                    makeUploadUrlRequest(log, "/panel/task_add_magnet_result", magnetUrl);
                     return new DaemonTaskSuccessResult(task);
 
                 case Remove:


### PR DESCRIPTION
Use `/panel/task_add_magnet_result` when passing link to torrent files.

Fixes https://github.com/erickok/transdroid/issues/622