### PR TITLE
qBittorrent 4.x+: Fix setting global upload and download limits

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
@@ -469,8 +469,8 @@ public class QBittorrentAdapter implements IDaemonAdapter {
                     String ul = (ratesTask.getUploadRate() == null ? "NaN" : Long.toString(ratesTask.getUploadRate() * 1024));
 
                     if (version >= 40100) {
-                        pathDL = "/api/v2/torrents/setDownloadLimit";
-                        pathUL = "/api/v2/torrents/setUploadLimit";
+                        pathDL = "/api/v2/transfer/setDownloadLimit";
+                        pathUL = "/api/v2/transfer/setUploadLimit";
                     } else {
                         pathDL = "/command/setGlobalDlLimit";
                         pathUL = "/command/setGlobalUpLimit";


### PR DESCRIPTION
Fix setting limits on qbittorrent 4.1+

https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-global-download-limit

Fixes https://github.com/erickok/transdroid/issues/630

Tested with qBittorrent 4.3.9.