### PR TITLE
Fix stripping space out of links but keep spaces in name intact

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
@@ -996,7 +996,8 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
 
         // Since v39 Chrome sends application/x-www-form-urlencoded magnet links and most torrent clients do not understand those, so decode first
         try {
-            url = URLDecoder.decode(url, "UTF-8");
+            url = URLDecoder.decode(url.replaceAll("\\s", ""), "UTF-8");
+            title = URLDecoder.decode(title, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             // Ignore: UTF-8 is always available on Android devices
         } catch (IllegalArgumentException e) {

--- a/app/src/main/java/org/transdroid/daemon/task/AddByMagnetUrlTask.java
+++ b/app/src/main/java/org/transdroid/daemon/task/AddByMagnetUrlTask.java
@@ -32,6 +32,6 @@ public class AddByMagnetUrlTask extends DaemonTask {
 		return new AddByMagnetUrlTask(adapter, data);
 	}
 	public String getUrl() {
-		return extras.getString("URL").replaceAll("\\s", "");
+		return extras.getString("URL");
 	}
 }


### PR DESCRIPTION
Move the stripping of whitespace from a torrent link to before the URL decode happens.
Hopefully this will still remove unwanted whitespace introduced by copy paste from the terminal as in https://github.com/erickok/transdroid/pull/551 while still encoding the spaces present in a magnet link as in https://github.com/erickok/transdroid/issues/618.

Fixes https://github.com/erickok/transdroid/issues/618
