### PR TITLE
Dont show stop button on Bitcomet

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Daemon.java
+++ b/app/src/main/java/org/transdroid/daemon/Daemon.java
@@ -337,7 +337,7 @@ public enum Daemon {
     }
 
     public static boolean supportsStoppingStarting(Daemon type) {
-        return type == uTorrent || type == rTorrent || type == BitTorrent || type == BitComet || type == Dummy;
+        return type == uTorrent || type == rTorrent || type == BitTorrent || type == Dummy;
     }
 
     public static boolean supportsForcedStarting(Daemon type) {


### PR DESCRIPTION
Remove bitcomet from the supportsStoppingStarting so we don't show an extra stop button.

Torrent stopped:
![bitcomet stopped](https://user-images.githubusercontent.com/1031504/200486960-ffdb2ffb-f941-45be-8d97-127791dff4cd.png)

Torrent started:
![bitcomet started](https://user-images.githubusercontent.com/1031504/200486972-ad0366e4-7352-44c6-8f99-ba7b0a231b2b.png)

Fixes https://github.com/erickok/transdroid/issues/634
