### PR TITLE
Allow pausing a torrent when queued

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/Torrent.java
+++ b/app/src/main/java/org/transdroid/daemon/Torrent.java
@@ -359,7 +359,7 @@ public final class Torrent implements Parcelable, Comparable<Torrent>, Finishabl
      */
     public boolean canPause() {
         // Can pause when it is downloading or seeding
-        return statusCode == TorrentStatus.Downloading || statusCode == TorrentStatus.Seeding;
+        return statusCode == TorrentStatus.Downloading || statusCode == TorrentStatus.Seeding || statusCode == TorrentStatus.Queued;
     }
 
     /**


### PR DESCRIPTION
Show the pause button on torrent details if the torrent is queued.
![queued after](https://user-images.githubusercontent.com/1031504/200492771-732223ab-e35c-45df-9587-1ef12e2fab72.png)

Fixes https://github.com/erickok/transdroid/issues/636
