### PR TITLE
Update gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 242
         versionName '2.5.22'
 
@@ -80,26 +80,27 @@ android {
 
 dependencies {
     // Android support
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.7.0'
 
     // Other
-    implementation 'org.androidannotations:androidannotations-api:4.7.0'
-    implementation 'org.androidannotations:ormlite-api:4.7.0'
-    implementation 'com.j256.ormlite:ormlite-core:5.1'
-    implementation 'com.j256.ormlite:ormlite-android:5.1'
+    implementation 'org.androidannotations:androidannotations-api:4.8.0'
+    implementation 'org.androidannotations:ormlite-api:4.8.0'
+    implementation 'com.j256.ormlite:ormlite-android:6.1'
     implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'com.nispok:snackbar:2.11.0'
-    implementation 'org.apache.openjpa:openjpa-lib:3.1.1'
+    implementation 'org.apache.openjpa:openjpa-lib:3.2.2'
     implementation 'net.iharder:base64:2.3.9'
     implementation('com.github.afollestad.material-dialogs:core:0.9.6.0@aar') {
         transitive = true
     }
-    implementation 'com.evernote:android-job:1.2.6'
+    implementation 'com.evernote:android-job:1.4.3'
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 
-    annotationProcessor 'org.androidannotations:androidannotations:4.7.0'
-    annotationProcessor 'org.androidannotations:ormlite:4.7.0'
+    annotationProcessor 'org.androidannotations:androidannotations:4.8.0'
+    annotationProcessor 'org.androidannotations:ormlite:4.8.0'
 }


### PR DESCRIPTION
Update gradle deps
Increase `minSdkVersion` to `21` to avoid `Error:Cannot fit requested classes in a single dex file`
Increase `compileSdkVersion` and `targetSdkVersion` to 33 to work with new dep versions
Add 
```
implementation "androidx.lifecycle:lifecycle-viewmodel:2.5.1"
implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
```
to avoid `Duplicate class androidx.lifecycle.ViewModelLazy found in modules jetified-lifecycle-viewmodel-ktx-2.3.1-runtime (androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1) and lifecycle-viewmodel-2.5.1-runtime (androidx.lifecycle:lifecycle-viewmodel:2.5.1)`

