### PR TITLE
rTorrent: also send `d.delete_tied` when removing torrent and data

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
@@ -219,6 +219,8 @@ public class RTorrentAdapter implements IDaemonAdapter {
                     if (removeTask.includingData()) {
                         makeRtorrentCall(log, "d.custom5.set",
                                 new String[]{task.getTargetTorrent().getUniqueID(), "1"});
+                        makeRtorrentCall(log, "d.delete_tied",
+                                new String[]{task.getTargetTorrent().getUniqueID()});
                     }
                     makeRtorrentCall(log, "d.erase", new String[]{task.getTargetTorrent().getUniqueID()});
                     return new DaemonTaskSuccessResult(task);


### PR DESCRIPTION
Also send a `d.delete_tied` if we want to remove torrent data, [just like ruTorrent](https://github.com/Novik/ruTorrent/blob/2a621cce63d71a2bda56e23ba8399ccae6755e56/plugins/erasedata/init.js#L45-L54).

Fixes https://github.com/erickok/transdroid/issues/654