### PR TITLE
qBittorrent: map `stoppedDL` and `stoppedUP` states to paused status

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
@@ -890,23 +890,20 @@ public class QBittorrentAdapter implements IDaemonAdapter {
                 return TorrentStatus.Error;
             case "downloading":
             case "metaDL":
-                return TorrentStatus.Downloading;
-            case "uploading":
-                return TorrentStatus.Seeding;
-            case "pausedDL":
-                return TorrentStatus.Paused;
-            case "pausedUP":
-                return TorrentStatus.Paused;
-            case "stalledUP":
-                return TorrentStatus.Seeding;
             case "stalledDL":
                 return TorrentStatus.Downloading;
+            case "uploading":
+            case "stalledUP":
+                return TorrentStatus.Seeding;
+            case "pausedDL":
+            case "pausedUP":
+            case "stoppedDL":
+            case "stoppedUP":
+                return TorrentStatus.Paused;
+            case "checkingDL":
             case "checkingUP":
                 return TorrentStatus.Checking;
-            case "checkingDL":
-                return TorrentStatus.Checking;
             case "queuedDL":
-                return TorrentStatus.Queued;
             case "queuedUP":
                 return TorrentStatus.Queued;
         }


### PR DESCRIPTION
In qBittorrent 5.x, these states replace `pausedDL` and `pausedUP`. This change is needed in addition to #674, otherwise paused/stopped entries will be displayed with unknown status.

See https://github.com/qbittorrent/qBittorrent/commit/5d1c2496063b41874e85af0145b153e006fc92d3#diff-855d251c4b031d765c3989ddca46e6454501d2f2f5a4313788cb3bcd016c6fe6 for details.

This PR also groups together the qBittorrent states that map to a given `TorrentStatus` value.