### PR TITLE
Fix translations

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -174,11 +174,11 @@
     <string name="pref_ftppass">FTP(S) парола</string>
     <string name="pref_disableauth">Без удостоверяване</string>
     <string name="pref_disableauth_info">Няма да бъдат изпращани данни за потребител и парола</string>
-    <string name="pref_sslenable">Позване на SSL</string>
+    <string name="pref_sslenable">Позване на TSL</string>
     <string name="pref_sslenable_info">Ще осъществява връзките посредством HTTPS</string>
-    <string name="pref_sslkey">Персонален SSL отпечатък (SHA-1)</string>
+    <string name="pref_sslkey">Персонален TSL отпечатък (SHA-1)</string>
     <string name="pref_sslkey_info">Разрешава само връзките към този конкретен сертификат</string>
-    <string name="pref_sslacceptall">Приемане на всеки SSL сертификат</string>
+    <string name="pref_sslacceptall">Приемане на всеки TSL сертификат</string>
     <string name="pref_sslacceptall_info">Разрешава всяка връзка</string>
     <string name="pref_notifyinterval">Интервал</string>
     <string name="pref_notifysound">Звук</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -174,11 +174,11 @@
     <string name="pref_ftppass">FTP(S) парола</string>
     <string name="pref_disableauth">Без удостоверяване</string>
     <string name="pref_disableauth_info">Няма да бъдат изпращани данни за потребител и парола</string>
-    <string name="pref_sslenable">Позване на TSL</string>
+    <string name="pref_sslenable">Позване на TLS</string>
     <string name="pref_sslenable_info">Ще осъществява връзките посредством HTTPS</string>
-    <string name="pref_sslkey">Персонален TSL отпечатък (SHA-1)</string>
+    <string name="pref_sslkey">Персонален TLS отпечатък (SHA-1)</string>
     <string name="pref_sslkey_info">Разрешава само връзките към този конкретен сертификат</string>
-    <string name="pref_sslacceptall">Приемане на всеки TSL сертификат</string>
+    <string name="pref_sslacceptall">Приемане на всеки TLS сертификат</string>
     <string name="pref_sslacceptall_info">Разрешава всяка връзка</string>
     <string name="pref_notifyinterval">Интервал</string>
     <string name="pref_notifysound">Звук</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -227,11 +227,11 @@
     <string name="pref_ftppass">FTP heslo</string>
     <string name="pref_disableauth">Zakázat ověřování</string>
     <string name="pref_disableauth_info">Neposílat uživatelské jméno a heslo</string>
-    <string name="pref_sslenable">Používat SSL</string>
+    <string name="pref_sslenable">Používat TSL</string>
     <string name="pref_sslenable_info">Připojit pomocí https</string>
-    <string name="pref_sslkey">Vlastní SSL otisk (SHA-1)</string>
+    <string name="pref_sslkey">Vlastní TSL otisk (SHA-1)</string>
     <string name="pref_sslkey_info">Povolit připojení pouze s tímto certifikátem</string>
-    <string name="pref_sslacceptall">Přijmout všechny SSL certifikáty</string>
+    <string name="pref_sslacceptall">Přijmout všechny TSL certifikáty</string>
     <string name="pref_sslacceptall_info">Povolit připojení se všemi otisky</string>
     <string name="pref_background">Upozornění na pozadí</string>
     <string name="pref_notifications_rss">Povolit RSS upozornění</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -227,11 +227,11 @@
     <string name="pref_ftppass">FTP heslo</string>
     <string name="pref_disableauth">Zakázat ověřování</string>
     <string name="pref_disableauth_info">Neposílat uživatelské jméno a heslo</string>
-    <string name="pref_sslenable">Používat TSL</string>
+    <string name="pref_sslenable">Používat TLS</string>
     <string name="pref_sslenable_info">Připojit pomocí https</string>
-    <string name="pref_sslkey">Vlastní TSL otisk (SHA-1)</string>
+    <string name="pref_sslkey">Vlastní TLS otisk (SHA-1)</string>
     <string name="pref_sslkey_info">Povolit připojení pouze s tímto certifikátem</string>
-    <string name="pref_sslacceptall">Přijmout všechny TSL certifikáty</string>
+    <string name="pref_sslacceptall">Přijmout všechny TLS certifikáty</string>
     <string name="pref_sslacceptall_info">Povolit připojení se všemi otisky</string>
     <string name="pref_background">Upozornění na pozadí</string>
     <string name="pref_notifications_rss">Povolit RSS upozornění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -243,11 +243,11 @@
     <string name="pref_ftppass">FTP(S) adgangskode</string>
     <string name="pref_disableauth">Deaktiver godkendelse</string>
     <string name="pref_disableauth_info">Send ikke brugernavn og adgangskode</string>
-    <string name="pref_sslenable">Brug SSL</string>
+    <string name="pref_sslenable">Brug TSL</string>
     <string name="pref_sslenable_info">Forbind via https</string>
-    <string name="pref_sslkey">Custom SSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Custom TSL thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Tillad kun forbindelser til dette specifikke certifikat</string>
-    <string name="pref_sslacceptall">Accepter alle SSL certifikater</string>
+    <string name="pref_sslacceptall">Accepter alle TSL certifikater</string>
     <string name="pref_sslacceptall_info">Tillad alle forbindelser fra ethvert thumbprint</string>
     <string name="pref_background">Baggrundsmeddelelser</string>
     <string name="pref_notifications_rss"> Aktiver RSS meddelelser</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -243,11 +243,11 @@
     <string name="pref_ftppass">FTP(S) adgangskode</string>
     <string name="pref_disableauth">Deaktiver godkendelse</string>
     <string name="pref_disableauth_info">Send ikke brugernavn og adgangskode</string>
-    <string name="pref_sslenable">Brug TSL</string>
+    <string name="pref_sslenable">Brug TLS</string>
     <string name="pref_sslenable_info">Forbind via https</string>
-    <string name="pref_sslkey">Custom TSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Custom TLS thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Tillad kun forbindelser til dette specifikke certifikat</string>
-    <string name="pref_sslacceptall">Accepter alle TSL certifikater</string>
+    <string name="pref_sslacceptall">Accepter alle TLS certifikater</string>
     <string name="pref_sslacceptall_info">Tillad alle forbindelser fra ethvert thumbprint</string>
     <string name="pref_background">Baggrundsmeddelelser</string>
     <string name="pref_notifications_rss"> Aktiver RSS meddelelser</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">(S) FTP-Passwort</string>
     <string name="pref_disableauth">Authentifizierung deaktivieren</string>
     <string name="pref_disableauth_info">Keinen Benutzernamen oder Passwort übertragen</string>
-    <string name="pref_sslenable">TSL verwenden</string>
+    <string name="pref_sslenable">TLS verwenden</string>
     <string name="pref_sslenable_info">Verbinden über https</string>
-    <string name="pref_sslkey">Benutzerdefinierten TSL Fingerabdruck (SHA-1)</string>
+    <string name="pref_sslkey">Benutzerdefinierten TLS Fingerabdruck (SHA-1)</string>
     <string name="pref_sslkey_info">Erlaube nur Verbindungen zu diesem bestimmten Zertifikat</string>
-    <string name="pref_sslacceptall">Alle TSL-Zertifikate zu akzeptieren</string>
+    <string name="pref_sslacceptall">Alle TLS-Zertifikate zu akzeptieren</string>
     <string name="pref_sslacceptall_info">Alle Verbindungen von jeder Fingerabdruck zulassen</string>
     <string name="pref_background">Hintergrund-Benachrichtigungen</string>
     <string name="pref_notifications_rss">RSS-Benachrichtigungen aktivieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">(S) FTP-Passwort</string>
     <string name="pref_disableauth">Authentifizierung deaktivieren</string>
     <string name="pref_disableauth_info">Keinen Benutzernamen oder Passwort übertragen</string>
-    <string name="pref_sslenable">SSL verwenden</string>
+    <string name="pref_sslenable">TSL verwenden</string>
     <string name="pref_sslenable_info">Verbinden über https</string>
-    <string name="pref_sslkey">Benutzerdefinierten SSL Fingerabdruck (SHA-1)</string>
+    <string name="pref_sslkey">Benutzerdefinierten TSL Fingerabdruck (SHA-1)</string>
     <string name="pref_sslkey_info">Erlaube nur Verbindungen zu diesem bestimmten Zertifikat</string>
-    <string name="pref_sslacceptall">Alle SSL-Zertifikate zu akzeptieren</string>
+    <string name="pref_sslacceptall">Alle TSL-Zertifikate zu akzeptieren</string>
     <string name="pref_sslacceptall_info">Alle Verbindungen von jeder Fingerabdruck zulassen</string>
     <string name="pref_background">Hintergrund-Benachrichtigungen</string>
     <string name="pref_notifications_rss">RSS-Benachrichtigungen aktivieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -203,11 +203,11 @@
     <string name="pref_ftppass">Contraseña (S)FTP</string>
     <string name="pref_disableauth">Deshabilitar autenticación</string>
     <string name="pref_disableauth_info">No enviar nombre de usuario y contraseña</string>
-    <string name="pref_sslenable">Usar SSL</string>
+    <string name="pref_sslenable">Usar TSL</string>
     <string name="pref_sslenable_info">Conectar usando https</string>
-    <string name="pref_sslkey">Firma digital SSL personalizada (SHA-1)</string>
+    <string name="pref_sslkey">Firma digital TSL personalizada (SHA-1)</string>
     <string name="pref_sslkey_info">Permitir únicamente conexiones a este certificado</string>
-    <string name="pref_sslacceptall">Aceptar todos los certificados SSL</string>
+    <string name="pref_sslacceptall">Aceptar todos los certificados TSL</string>
     <string name="pref_sslacceptall_info">Permitir todas las conexiones de cualquier firma digital</string>
     <string name="pref_background">Notificaciones en segundo plano</string>
     <string name="pref_notifications_rss">Habilitar notificaciones RSS</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -203,11 +203,11 @@
     <string name="pref_ftppass">Contraseña (S)FTP</string>
     <string name="pref_disableauth">Deshabilitar autenticación</string>
     <string name="pref_disableauth_info">No enviar nombre de usuario y contraseña</string>
-    <string name="pref_sslenable">Usar TSL</string>
+    <string name="pref_sslenable">Usar TLS</string>
     <string name="pref_sslenable_info">Conectar usando https</string>
-    <string name="pref_sslkey">Firma digital TSL personalizada (SHA-1)</string>
+    <string name="pref_sslkey">Firma digital TLS personalizada (SHA-1)</string>
     <string name="pref_sslkey_info">Permitir únicamente conexiones a este certificado</string>
-    <string name="pref_sslacceptall">Aceptar todos los certificados TSL</string>
+    <string name="pref_sslacceptall">Aceptar todos los certificados TLS</string>
     <string name="pref_sslacceptall_info">Permitir todas las conexiones de cualquier firma digital</string>
     <string name="pref_background">Notificaciones en segundo plano</string>
     <string name="pref_notifications_rss">Habilitar notificaciones RSS</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -157,7 +157,7 @@
     <string name="pref_folder_info">Tavaliselt tühi</string>
     <string name="pref_optional">Vabatahtlikud sätted</string>
     <string name="pref_os">Serveri OS</string>
-    <string name="pref_sslenable">Kasuta TSL-i</string>
+    <string name="pref_sslenable">Kasuta TLS-i</string>
     <string name="pref_notifysound">Heli</string>
     <string name="pref_system">Süsteem</string>
     <string name="pref_autorefresh">Automaatne uuendus</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -157,7 +157,7 @@
     <string name="pref_folder_info">Tavaliselt tühi</string>
     <string name="pref_optional">Vabatahtlikud sätted</string>
     <string name="pref_os">Serveri OS</string>
-    <string name="pref_sslenable">Kasuta SSL-i</string>
+    <string name="pref_sslenable">Kasuta TSL-i</string>
     <string name="pref_notifysound">Heli</string>
     <string name="pref_system">Süsteem</string>
     <string name="pref_autorefresh">Automaatne uuendus</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -252,7 +252,7 @@
     <string name="pref_disableauth_info">نام‌کاربری و گذرواژه را نفرست</string>
     <string name="pref_sslenable">استفاده از اس اس ال	</string>
     <string name="pref_sslenable_info">اتصال با استفاده از HTTPS	</string>
-    <string name="pref_sslkey">انگشت زدن پای سفارشی TSL (SHA-1)	</string>
+    <string name="pref_sslkey">انگشت زدن پای سفارشی TLS (SHA-1)	</string>
     <string name="pref_sslkey_info">فقط اجازه اتصال به این گواهی خاص	</string>
     <string name="pref_sslacceptall">قبول همه گواهینامه های اس اس ال	</string>
     <string name="pref_sslacceptall_info">اجازه به تمام اتصالات از هر اثر انگشت</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -252,7 +252,7 @@
     <string name="pref_disableauth_info">نام‌کاربری و گذرواژه را نفرست</string>
     <string name="pref_sslenable">استفاده از اس اس ال	</string>
     <string name="pref_sslenable_info">اتصال با استفاده از HTTPS	</string>
-    <string name="pref_sslkey">انگشت زدن پای سفارشی SSL (SHA-1)	</string>
+    <string name="pref_sslkey">انگشت زدن پای سفارشی TSL (SHA-1)	</string>
     <string name="pref_sslkey_info">فقط اجازه اتصال به این گواهی خاص	</string>
     <string name="pref_sslacceptall">قبول همه گواهینامه های اس اس ال	</string>
     <string name="pref_sslacceptall_info">اجازه به تمام اتصالات از هر اثر انگشت</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -113,7 +113,7 @@
     <string name="pref_os">Pavelimen OS</string>
     <string name="pref_downdir">Lataus hakemisto</string>
     <string name="pref_ftppass">(S)FTP salasana</string>
-    <string name="pref_sslenable">Käytä SSL</string>
+    <string name="pref_sslenable">Käytä TSL</string>
     <string name="pref_sslenable_info">Yhdistä käyttäen https</string>
     <string name="pref_notifications_info">Aktivoi taustapalvelut</string>
     <string name="pref_notifyinterval">Aikaväli</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -113,7 +113,7 @@
     <string name="pref_os">Pavelimen OS</string>
     <string name="pref_downdir">Lataus hakemisto</string>
     <string name="pref_ftppass">(S)FTP salasana</string>
-    <string name="pref_sslenable">Käytä TSL</string>
+    <string name="pref_sslenable">Käytä TLS</string>
     <string name="pref_sslenable_info">Yhdistä käyttäen https</string>
     <string name="pref_notifications_info">Aktivoi taustapalvelut</string>
     <string name="pref_notifyinterval">Aikaväli</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -243,11 +243,11 @@
     <string name="pref_ftppass">Mot de passe (S)FTP</string>
     <string name="pref_disableauth">Désactive l\'authentification</string>
     <string name="pref_disableauth_info">Ne pas envoyer le nom et le mot de passe</string>
-    <string name="pref_sslenable">Utiliser TSL</string>
+    <string name="pref_sslenable">Utiliser TLS</string>
     <string name="pref_sslenable_info">Connection avec le protocole https</string>
-    <string name="pref_sslkey">Empreinte TSL personnalisée (SHA-1)</string>
+    <string name="pref_sslkey">Empreinte TLS personnalisée (SHA-1)</string>
     <string name="pref_sslkey_info">N\'autoriser que les connexions à ce certificat spécifique</string>
-    <string name="pref_sslacceptall">Accepter tous les certificats TSL</string>
+    <string name="pref_sslacceptall">Accepter tous les certificats TLS</string>
     <string name="pref_sslacceptall_info">Autoriser toutes les connexions à partir de n\'importe quel empreinte</string>
     <string name="pref_background">Notifications d\'arrière-plan</string>
     <string name="pref_notifications_rss">Active les notifications RSS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -243,11 +243,11 @@
     <string name="pref_ftppass">Mot de passe (S)FTP</string>
     <string name="pref_disableauth">Désactive l\'authentification</string>
     <string name="pref_disableauth_info">Ne pas envoyer le nom et le mot de passe</string>
-    <string name="pref_sslenable">Utiliser SSL</string>
+    <string name="pref_sslenable">Utiliser TSL</string>
     <string name="pref_sslenable_info">Connection avec le protocole https</string>
-    <string name="pref_sslkey">Empreinte SSL personnalisée (SHA-1)</string>
+    <string name="pref_sslkey">Empreinte TSL personnalisée (SHA-1)</string>
     <string name="pref_sslkey_info">N\'autoriser que les connexions à ce certificat spécifique</string>
-    <string name="pref_sslacceptall">Accepter tous les certificats SSL</string>
+    <string name="pref_sslacceptall">Accepter tous les certificats TSL</string>
     <string name="pref_sslacceptall_info">Autoriser toutes les connexions à partir de n\'importe quel empreinte</string>
     <string name="pref_background">Notifications d\'arrière-plan</string>
     <string name="pref_notifications_rss">Active les notifications RSS</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">FTP(S) jelszó</string>
     <string name="pref_disableauth">Tiltsa le a hitelesítést</string>
     <string name="pref_disableauth_info">Ne küldje el a felhasználónevet és a jelszót</string>
-    <string name="pref_sslenable">SSL használata</string>
+    <string name="pref_sslenable">TSL használata</string>
     <string name="pref_sslenable_info">Kapcsolódás https használatával</string>
-    <string name="pref_sslkey">Egyéni SSL ujjlenyomat (SHA-1)</string>
+    <string name="pref_sslkey">Egyéni TSL ujjlenyomat (SHA-1)</string>
     <string name="pref_sslkey_info">Engedély csak a megadott tanúsítványú kapcsolatokhoz</string>
-    <string name="pref_sslacceptall">Fogadjon el minden SSL tanúsítványt</string>
+    <string name="pref_sslacceptall">Fogadjon el minden TSL tanúsítványt</string>
     <string name="pref_sslacceptall_info">Minden kapcsolat engedélyre bármilyen ujjlenyomattól</string>
     <string name="pref_background">Háttér értesítések</string>
     <string name="pref_notifications_rss">RSS értesítések engedélyezése</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">FTP(S) jelszó</string>
     <string name="pref_disableauth">Tiltsa le a hitelesítést</string>
     <string name="pref_disableauth_info">Ne küldje el a felhasználónevet és a jelszót</string>
-    <string name="pref_sslenable">TSL használata</string>
+    <string name="pref_sslenable">TLS használata</string>
     <string name="pref_sslenable_info">Kapcsolódás https használatával</string>
-    <string name="pref_sslkey">Egyéni TSL ujjlenyomat (SHA-1)</string>
+    <string name="pref_sslkey">Egyéni TLS ujjlenyomat (SHA-1)</string>
     <string name="pref_sslkey_info">Engedély csak a megadott tanúsítványú kapcsolatokhoz</string>
-    <string name="pref_sslacceptall">Fogadjon el minden TSL tanúsítványt</string>
+    <string name="pref_sslacceptall">Fogadjon el minden TLS tanúsítványt</string>
     <string name="pref_sslacceptall_info">Minden kapcsolat engedélyre bármilyen ujjlenyomattól</string>
     <string name="pref_background">Háttér értesítések</string>
     <string name="pref_notifications_rss">RSS értesítések engedélyezése</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Password (S) FTP</string>
     <string name="pref_disableauth">Disabilita autenticazione</string>
     <string name="pref_disableauth_info">Non inviare username e password</string>
-    <string name="pref_sslenable">Usa SSL</string>
+    <string name="pref_sslenable">Usa TSL</string>
     <string name="pref_sslenable_info">Connetti utilizzando https</string>
-    <string name="pref_sslkey">Identificazione personalizzata per SSL (SHA-1)</string>
+    <string name="pref_sslkey">Identificazione personalizzata per TSL (SHA-1)</string>
     <string name="pref_sslkey_info">Permetti solo connessioni con questo certificato</string>
-    <string name="pref_sslacceptall">Accetta tutti i certificati SSL</string>
+    <string name="pref_sslacceptall">Accetta tutti i certificati TSL</string>
     <string name="pref_sslacceptall_info">Consenti tutte le connessioni da qualsiasi identificazione personale</string>
     <string name="pref_background">Notifiche in backgroud</string>
     <string name="pref_notifications_rss">Abilita notifiche RSS</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Password (S) FTP</string>
     <string name="pref_disableauth">Disabilita autenticazione</string>
     <string name="pref_disableauth_info">Non inviare username e password</string>
-    <string name="pref_sslenable">Usa TSL</string>
+    <string name="pref_sslenable">Usa TLS</string>
     <string name="pref_sslenable_info">Connetti utilizzando https</string>
-    <string name="pref_sslkey">Identificazione personalizzata per TSL (SHA-1)</string>
+    <string name="pref_sslkey">Identificazione personalizzata per TLS (SHA-1)</string>
     <string name="pref_sslkey_info">Permetti solo connessioni con questo certificato</string>
-    <string name="pref_sslacceptall">Accetta tutti i certificati TSL</string>
+    <string name="pref_sslacceptall">Accetta tutti i certificati TLS</string>
     <string name="pref_sslacceptall_info">Consenti tutte le connessioni da qualsiasi identificazione personale</string>
     <string name="pref_background">Notifiche in backgroud</string>
     <string name="pref_notifications_rss">Abilita notifiche RSS</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -198,11 +198,11 @@
     <string name="pref_ftppass">סיסמת השרת FTP/S</string>
     <string name="pref_disableauth">ללא אימות</string>
     <string name="pref_disableauth_info">התחברות אנונומית</string>
-    <string name="pref_sslenable">השתמש בSSL</string>
+    <string name="pref_sslenable">השתמש בTSL</string>
     <string name="pref_sslenable_info">התחבר באמצעות HTTPS</string>
-    <string name="pref_sslkey">חתימת SSL מותאמת אישית (SHA-1)</string>
+    <string name="pref_sslkey">חתימת TSL מותאמת אישית (SHA-1)</string>
     <string name="pref_sslkey_info">אפשר חיבורים רק עם מפתח זה</string>
-    <string name="pref_sslacceptall">אפשר את כל התעודות SSL</string>
+    <string name="pref_sslacceptall">אפשר את כל התעודות TSL</string>
     <string name="pref_sslacceptall_info">אפשר את כל החיבורים</string>
     <string name="pref_background">התרעות ברקע</string>
     <string name="pref_notifications_rss">אפשר התרעות RSS</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -198,11 +198,11 @@
     <string name="pref_ftppass">סיסמת השרת FTP/S</string>
     <string name="pref_disableauth">ללא אימות</string>
     <string name="pref_disableauth_info">התחברות אנונומית</string>
-    <string name="pref_sslenable">השתמש בTSL</string>
+    <string name="pref_sslenable">השתמש בTLS</string>
     <string name="pref_sslenable_info">התחבר באמצעות HTTPS</string>
-    <string name="pref_sslkey">חתימת TSL מותאמת אישית (SHA-1)</string>
+    <string name="pref_sslkey">חתימת TLS מותאמת אישית (SHA-1)</string>
     <string name="pref_sslkey_info">אפשר חיבורים רק עם מפתח זה</string>
-    <string name="pref_sslacceptall">אפשר את כל התעודות TSL</string>
+    <string name="pref_sslacceptall">אפשר את כל התעודות TLS</string>
     <string name="pref_sslacceptall_info">אפשר את כל החיבורים</string>
     <string name="pref_background">התרעות ברקע</string>
     <string name="pref_notifications_rss">אפשר התרעות RSS</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -251,11 +251,11 @@
     <string name="pref_ftppass">FTP パスワード</string>
     <string name="pref_disableauth">認証を無効</string>
     <string name="pref_disableauth_info">ユーザー名とパスワードを送信しません</string>
-    <string name="pref_sslenable">TSL を使用</string>
+    <string name="pref_sslenable">TLS を使用</string>
     <string name="pref_sslenable_info">https を使用して接続します</string>
-    <string name="pref_sslkey">カスタム TSL サムプリント (SHA-1)</string>
+    <string name="pref_sslkey">カスタム TLS サムプリント (SHA-1)</string>
     <string name="pref_sslkey_info">この特定の証明書のみ接続を許可します</string>
-    <string name="pref_sslacceptall">すべての TSL 証明書を受付</string>
+    <string name="pref_sslacceptall">すべての TLS 証明書を受付</string>
     <string name="pref_sslacceptall_info">すべてのサムプリントですべての接続を許可します</string>
     <string name="pref_background">バックグランド通知</string>
     <string name="pref_notifications_rss">RSS 通知を有効</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -251,11 +251,11 @@
     <string name="pref_ftppass">FTP パスワード</string>
     <string name="pref_disableauth">認証を無効</string>
     <string name="pref_disableauth_info">ユーザー名とパスワードを送信しません</string>
-    <string name="pref_sslenable">SSL を使用</string>
+    <string name="pref_sslenable">TSL を使用</string>
     <string name="pref_sslenable_info">https を使用して接続します</string>
-    <string name="pref_sslkey">カスタム SSL サムプリント (SHA-1)</string>
+    <string name="pref_sslkey">カスタム TSL サムプリント (SHA-1)</string>
     <string name="pref_sslkey_info">この特定の証明書のみ接続を許可します</string>
-    <string name="pref_sslacceptall">すべての SSL 証明書を受付</string>
+    <string name="pref_sslacceptall">すべての TSL 証明書を受付</string>
     <string name="pref_sslacceptall_info">すべてのサムプリントですべての接続を許可します</string>
     <string name="pref_background">バックグランド通知</string>
     <string name="pref_notifications_rss">RSS 通知を有効</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -251,11 +251,11 @@
     <string name="pref_ftppass">FTP(S) 암호</string>
     <string name="pref_disableauth">인증 비활성화</string>
     <string name="pref_disableauth_info">계정 및 암호를 전송하지 않습니다</string>
-    <string name="pref_sslenable">TSL 사용</string>
+    <string name="pref_sslenable">TLS 사용</string>
     <string name="pref_sslenable_info">https 프로토콜로 연결합니다</string>
-    <string name="pref_sslkey">사용자 TSL 손도장 (SHA-1)</string>
+    <string name="pref_sslkey">사용자 TLS 손도장 (SHA-1)</string>
     <string name="pref_sslkey_info">특정 인증서로의 연결만 허용합니다</string>
-    <string name="pref_sslacceptall">모든 TSL 인증서 허용</string>
+    <string name="pref_sslacceptall">모든 TLS 인증서 허용</string>
     <string name="pref_sslacceptall_info">손도장에 관계없이 모든 연결을 허용합니다</string>
     <string name="pref_background">백그라운드 알림</string>
     <string name="pref_notifications_rss">RSS 알림 활성화</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -251,11 +251,11 @@
     <string name="pref_ftppass">FTP(S) 암호</string>
     <string name="pref_disableauth">인증 비활성화</string>
     <string name="pref_disableauth_info">계정 및 암호를 전송하지 않습니다</string>
-    <string name="pref_sslenable">SSL 사용</string>
+    <string name="pref_sslenable">TSL 사용</string>
     <string name="pref_sslenable_info">https 프로토콜로 연결합니다</string>
-    <string name="pref_sslkey">사용자 SSL 손도장 (SHA-1)</string>
+    <string name="pref_sslkey">사용자 TSL 손도장 (SHA-1)</string>
     <string name="pref_sslkey_info">특정 인증서로의 연결만 허용합니다</string>
-    <string name="pref_sslacceptall">모든 SSL 인증서 허용</string>
+    <string name="pref_sslacceptall">모든 TSL 인증서 허용</string>
     <string name="pref_sslacceptall_info">손도장에 관계없이 모든 연결을 허용합니다</string>
     <string name="pref_background">백그라운드 알림</string>
     <string name="pref_notifications_rss">RSS 알림 활성화</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -255,12 +255,12 @@
     <string name="pref_ftppass">(S)FTP-wachtwoord</string>
     <string name="pref_disableauth">Geen authenticatie gebruiken</string>
     <string name="pref_disableauth_info">Negeer gebruikersnaam en wachtwoord</string>
-    <string name="pref_sslenable">Gebruik TSL</string>
+    <string name="pref_sslenable">Gebruik TLS</string>
     <string name="pref_sslenable_info">Via https verbinden</string>
-    <string name="pref_sslkey">Handmatige TSL-vingerafdruk (SHA-1)</string>
+    <string name="pref_sslkey">Handmatige TLS-vingerafdruk (SHA-1)</string>
     <string name="pref_sslkey_info">Alleen verbindingen met dit certificaat toestaan</string>
-    <string name="pref_sslacceptall">Alle TSL-certificaten toestaan</string>
-    <string name="pref_sslacceptall_info">Verbindingen met alle TSL-vingerafdrukken toestaan</string>
+    <string name="pref_sslacceptall">Alle TLS-certificaten toestaan</string>
+    <string name="pref_sslacceptall_info">Verbindingen met alle TLS-vingerafdrukken toestaan</string>
     <string name="pref_background">Meldingen op achtergrond</string>
     <string name="pref_notifications_rss">RSS meldingen aanzetten</string>
     <string name="pref_notifications_torrent">Torrent meldingen aanzetten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -255,12 +255,12 @@
     <string name="pref_ftppass">(S)FTP-wachtwoord</string>
     <string name="pref_disableauth">Geen authenticatie gebruiken</string>
     <string name="pref_disableauth_info">Negeer gebruikersnaam en wachtwoord</string>
-    <string name="pref_sslenable">Gebruik SSL</string>
+    <string name="pref_sslenable">Gebruik TSL</string>
     <string name="pref_sslenable_info">Via https verbinden</string>
-    <string name="pref_sslkey">Handmatige SSL-vingerafdruk (SHA-1)</string>
+    <string name="pref_sslkey">Handmatige TSL-vingerafdruk (SHA-1)</string>
     <string name="pref_sslkey_info">Alleen verbindingen met dit certificaat toestaan</string>
-    <string name="pref_sslacceptall">Alle SSL-certificaten toestaan</string>
-    <string name="pref_sslacceptall_info">Verbindingen met alle SSL-vingerafdrukken toestaan</string>
+    <string name="pref_sslacceptall">Alle TSL-certificaten toestaan</string>
+    <string name="pref_sslacceptall_info">Verbindingen met alle TSL-vingerafdrukken toestaan</string>
     <string name="pref_background">Meldingen op achtergrond</string>
     <string name="pref_notifications_rss">RSS meldingen aanzetten</string>
     <string name="pref_notifications_torrent">Torrent meldingen aanzetten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -225,11 +225,11 @@
     <string name="pref_ftppass">Hasło FTP(S)</string>
     <string name="pref_disableauth">Wyłącz uwierzytelnianie</string>
     <string name="pref_disableauth_info">Nie wysyłaj loginu i hasła</string>
-    <string name="pref_sslenable">Użyj SSL</string>
+    <string name="pref_sslenable">Użyj TSL</string>
     <string name="pref_sslenable_info">Połącz używając https</string>
-    <string name="pref_sslkey">Dostosuj podpis SSL (SHA-1)</string>
+    <string name="pref_sslkey">Dostosuj podpis TSL (SHA-1)</string>
     <string name="pref_sslkey_info">Zezwól tylko na połączenia z tym certyfikatem</string>
-    <string name="pref_sslacceptall">Akceptuj wszystkie certyfikaty SSL</string>
+    <string name="pref_sslacceptall">Akceptuj wszystkie certyfikaty TSL</string>
     <string name="pref_sslacceptall_info">Zezwalaj na wszystkie połączenia</string>
     <string name="pref_background">Powiadomienia w tle</string>
     <string name="pref_notifications_rss">Włącz powiadomienia RSS</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -225,11 +225,11 @@
     <string name="pref_ftppass">Hasło FTP(S)</string>
     <string name="pref_disableauth">Wyłącz uwierzytelnianie</string>
     <string name="pref_disableauth_info">Nie wysyłaj loginu i hasła</string>
-    <string name="pref_sslenable">Użyj TSL</string>
+    <string name="pref_sslenable">Użyj TLS</string>
     <string name="pref_sslenable_info">Połącz używając https</string>
-    <string name="pref_sslkey">Dostosuj podpis TSL (SHA-1)</string>
+    <string name="pref_sslkey">Dostosuj podpis TLS (SHA-1)</string>
     <string name="pref_sslkey_info">Zezwól tylko na połączenia z tym certyfikatem</string>
-    <string name="pref_sslacceptall">Akceptuj wszystkie certyfikaty TSL</string>
+    <string name="pref_sslacceptall">Akceptuj wszystkie certyfikaty TLS</string>
     <string name="pref_sslacceptall_info">Zezwalaj na wszystkie połączenia</string>
     <string name="pref_background">Powiadomienia w tle</string>
     <string name="pref_notifications_rss">Włącz powiadomienia RSS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Senha do servidor FTP(S)</string>
     <string name="pref_disableauth">Desativar autenticação</string>
     <string name="pref_disableauth_info">Não enviar nome de usuário e senha</string>
-    <string name="pref_sslenable">Utilizar SSL</string>
+    <string name="pref_sslenable">Utilizar TSL</string>
     <string name="pref_sslenable_info">Conectar usando HTTPS</string>
-    <string name="pref_sslkey">SSL thumbprint (SHA-1) Personalizada</string>
+    <string name="pref_sslkey">TSL thumbprint (SHA-1) Personalizada</string>
     <string name="pref_sslkey_info">Permitir apenas conexões para este certificado específico</string>
-    <string name="pref_sslacceptall">Aceitar todos os certificados SSL</string>
+    <string name="pref_sslacceptall">Aceitar todos os certificados TSL</string>
     <string name="pref_sslacceptall_info">Permitir todas as conexões de qualquer thumbprint</string>
     <string name="pref_background">Notificações de segundo plano</string>
     <string name="pref_notifications_rss">Permitir notificações RSS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Senha do servidor FTP(S)</string>
     <string name="pref_disableauth">Desativar autenticação</string>
     <string name="pref_disableauth_info">Não enviar nome de usuário e senha</string>
-    <string name="pref_sslenable">Utilizar TSL</string>
+    <string name="pref_sslenable">Utilizar TLS</string>
     <string name="pref_sslenable_info">Conectar usando HTTPS</string>
-    <string name="pref_sslkey">TSL thumbprint (SHA-1) Personalizada</string>
+    <string name="pref_sslkey">TLS thumbprint (SHA-1) Personalizada</string>
     <string name="pref_sslkey_info">Permitir apenas conexões para este certificado específico</string>
-    <string name="pref_sslacceptall">Aceitar todos os certificados TSL</string>
+    <string name="pref_sslacceptall">Aceitar todos os certificados TLS</string>
     <string name="pref_sslacceptall_info">Permitir todas as conexões de qualquer thumbprint</string>
     <string name="pref_background">Notificações de segundo plano</string>
     <string name="pref_notifications_rss">Permitir notificações RSS</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Senha FTP(S)</string>
     <string name="pref_disableauth">Desativar autenticação</string>
     <string name="pref_disableauth_info">Não enviar nome de utilizador e senha</string>
-    <string name="pref_sslenable">Utilizar TSL</string>
+    <string name="pref_sslenable">Utilizar TLS</string>
     <string name="pref_sslenable_info">Ligar através de https</string>
-    <string name="pref_sslkey">Impressão digital TSL personalizada (SHA-1)</string>
+    <string name="pref_sslkey">Impressão digital TLS personalizada (SHA-1)</string>
     <string name="pref_sslkey_info">Permitir apenas ligações para este certificado específico</string>
-    <string name="pref_sslacceptall">Aceitar todos os certificados TSL</string>
+    <string name="pref_sslacceptall">Aceitar todos os certificados TLS</string>
     <string name="pref_sslacceptall_info">Permitir todas as ligações de qualquer impressão digital</string>
     <string name="pref_background">Notificações fundo</string>
     <string name="pref_notifications_rss">Ativar notificações de RSS</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">Senha FTP(S)</string>
     <string name="pref_disableauth">Desativar autenticação</string>
     <string name="pref_disableauth_info">Não enviar nome de utilizador e senha</string>
-    <string name="pref_sslenable">Utilizar SSL</string>
+    <string name="pref_sslenable">Utilizar TSL</string>
     <string name="pref_sslenable_info">Ligar através de https</string>
-    <string name="pref_sslkey">Impressão digital SSL personalizada (SHA-1)</string>
+    <string name="pref_sslkey">Impressão digital TSL personalizada (SHA-1)</string>
     <string name="pref_sslkey_info">Permitir apenas ligações para este certificado específico</string>
-    <string name="pref_sslacceptall">Aceitar todos os certificados SSL</string>
+    <string name="pref_sslacceptall">Aceitar todos os certificados TSL</string>
     <string name="pref_sslacceptall_info">Permitir todas as ligações de qualquer impressão digital</string>
     <string name="pref_background">Notificações fundo</string>
     <string name="pref_notifications_rss">Ativar notificações de RSS</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -276,11 +276,11 @@
     <string name="pref_ftppass">Пароль FTP(S)</string>
     <string name="pref_disableauth">Отключить аутентификацию</string>
     <string name="pref_disableauth_info">Не отправлять имя пользователя и пароль</string>
-    <string name="pref_sslenable">Использовать TSL</string>
+    <string name="pref_sslenable">Использовать TLS</string>
     <string name="pref_sslenable_info">Подключение с помощью HTTPS</string>
-    <string name="pref_sslkey">Пользовательское хеш-значение TSL (SHA-1)</string>
+    <string name="pref_sslkey">Пользовательское хеш-значение TLS (SHA-1)</string>
     <string name="pref_sslkey_info">Разрешить только подключения к указанному сертификату</string>
-    <string name="pref_sslacceptall">Принимать все TSL-сертификаты</string>
+    <string name="pref_sslacceptall">Принимать все TLS-сертификаты</string>
     <string name="pref_sslacceptall_info">Разрешить все подключения от любых хеш-значений</string>
     <string name="pref_background">Фоновые уведомления</string>
     <string name="pref_notifications_rss">Включить уведомления RSS-лент</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -20,10 +20,11 @@
     <string name="action_addall">Добавить все</string>
     <string name="action_addfromfile">Из файла</string>
     <string name="action_addfromurl">Из URL-адреса</string>
-    <string name="action_scanbarcode">Сканировать штрих-код</string>
+    <string name="action_scanbarcode">Сканировать QR-код</string>
     <string name="action_search">Поиск</string>
     <string name="action_refresh">Обновить</string>
     <string name="action_rss">RSS-ленты</string>
+    <string name="action_remoterss">Удалённые RSS</string>
     <string name="action_enableturtle">Включить режим ограничения скорости</string>
     <string name="action_disableturtle">Отключить режим ограничения скорости</string>
     <string name="action_sort">Сортировать список</string>
@@ -72,6 +73,9 @@
     <string name="action_removesettings">Удалить сервер</string>
     <string name="action_visitwebsite">Посетить transdroid.org</string>
     <string name="action_close">Закрыть</string>
+
+    <string name="navigation_opendrawer">Выберите сервер и фильтр</string>
+    <string name="navigation_closedrawer">Закрыть список фильтров</string>
     <string name="navigation_nosettings">%1$s позволяет отслеживать и управлять вашими торрент-клиентами запущенными дома или на ваших сидбоксах. Установка и настройка приложения может вызвать некоторые затруднения, но мы предлагаем вам пошаговую инструкцию и обещаем, что все, приложенные вами, усилия будут того стоить!</string>
     <string name="navigation_emptytorrents">Соединение установлено, но нет загрузок соответствующих текущему фильтру</string>
     <string name="navigation_emptydetails">Выберите загрузку для просмотра подробной информации</string>
@@ -97,6 +101,8 @@
     <string name="navigation_selectfinished">Выбор готовой</string>
     <string name="navigation_invertselection">Инвертировать выделение</string>
     <string name="navigation_pickserver">Добавить торрент в...</string>
+    <string name="navigation_rss_tabs_remote">Сервер</string>
+
     <string name="status_status">СТАТУС: %1$s</string>
     <string name="status_waiting">Ожидание проверки&#8230;</string>
     <string name="status_checking">Проверка хэша...</string>
@@ -212,6 +218,11 @@
         <item quantity="other">В RSS-ленте доступно %1$s новых торрентов</item>
     </plurals>
     <string name="rss_service_newfor">Новые торренты от %1$s</string>
+
+    <string name="remoterss_filter_allrecent">(Все недавние)</string>
+    <string name="remoterss_no_files">На найдено торент файлов.\n\nВаша RSS лента настроена правильно?</string>
+    <string name="remoterss_loading">Загрузка RSS потока…</string>
+
     <string name="widget_loading">Загрузка&#8230;</string>
     <string name="widget_opentransdroid">Открыть Transdroid</string>
     <string name="widget_filter">ПРОСМОТР СЕРВЕРА</string>
@@ -221,8 +232,10 @@
     <string name="widget_showstatusview">Статистика сервера вместо названия</string>
     <string name="widget_usedarktheme">Использовать темную тему (без предпросмотра)</string>
     <string name="widget_done">ГОТОВО</string>
+
     <string name="pref_servers">Серверы</string>
     <string name="pref_addserver">Добавить новый сервер</string>
+    <string name="pref_addserver_normal">Добавить обычный, свой сервер</string>
     <string name="pref_addseedbox">Добавить сидбокс</string>
     <string name="pref_defaultserver">Сервер по умолчанию</string>
     <string name="pref_defaultserver_lastused">Последний используемый</string>
@@ -234,8 +247,9 @@
     <string name="pref_addrssfeed">Добавить RSS-ленту</string>
     <string name="pref_others">Дополнительно</string>
     <string name="pref_confirmremove">Вы уверены, что хотите удалить эти настройки?</string>
-    <string name="pref_name">Имя</string>
-    <string name="pref_name_optional">Необязательно. Имя поискового сайта</string>
+
+    <string name="pref_name">Название</string>
+    <string name="pref_name_optional">Необязательно. Название поискового сайта</string>
     <string name="pref_searchurl">URL-адрес прямого поиска</string>
     <string name="pref_searchurl_info">поисковый запрос будет заменен на %s</string>
     <string name="pref_cookies">Куки</string>
@@ -245,8 +259,13 @@
     <string name="pref_reqauth_info">Открывает ссылки в веб-браузере для входа пользователя в систему</string>
     <string name="pref_alarmrssnew">Уведомлять о новых раздачах</string>
     <string name="pref_alarmrssnew_info">Уведомление при появлении новых торрентов</string>
+    <string name="pref_alarmrssexclude">Фильтр на исключение</string>
+    <string name="pref_alarmrssexclude_info">Не показывать если название торрента содержит эти слова разделённые через |</string>
+    <string name="pref_alarmrssinclude">Фильтр на включение</string>
+    <string name="pref_alarmrssinclude_info">Показывать только если название торрента содержит эти слова разделённые через |</string>
+
     <string name="pref_servertype">Тип сервера</string>
-    <string name="pref_address">IP или имя хоста</string>
+    <string name="pref_address">IP или хост</string>
     <string name="pref_port">Номер порта</string>
     <string name="pref_user">Имя пользователя</string>
     <string name="pref_pass">Пароль</string>
@@ -258,6 +277,8 @@
     <string name="pref_localport">Номер локального порта</string>
     <string name="pref_localnetwork">Локальная сеть</string>
     <string name="pref_localnetwork_info">SSID локальной сети сервера</string>
+    <string name="pref_local_permission_title">Разрешение знать местоположение</string>
+    <string name="pref_local_permission_rationale">Чтобы знать SSID подключённой Wifi сети, для %1$s требуется разрешение на запрос местоположения</string>
     <string name="pref_folder">Папка</string>
     <string name="pref_folder_info">Обычно не указывается</string>
     <string name="pref_scgifolder">Точка монтирования SCGI</string>
@@ -266,6 +287,10 @@
     <string name="pref_alarmdone_info">Уведомлять при завершении загрузки торрента</string>
     <string name="pref_alarmnew">Уведомление о новом торренте</string>
     <string name="pref_alarmnew_info">Уведомлять при добавлении торрента</string>
+    <string name="pref_alarmexclude">Фильтр на исключение</string>
+    <string name="pref_alarmexclude_info">Уведомлять только если название торрента не содержит эти слова разделённые через |</string>
+    <string name="pref_alarminclude">Фильтр на включение</string>
+    <string name="pref_alarminclude_info">Уведомлять только если название торрента не содержит эти слова разделённые через |</string>
     <string name="pref_os">Операционная система сервера</string>
     <string name="pref_downdir">Папка загрузок</string>
     <string name="pref_downdir_info">Вручную задать абсолютный путь для удаленных подключений</string>
@@ -281,7 +306,12 @@
     <string name="pref_sslkey">Пользовательское хеш-значение TLS (SHA-1)</string>
     <string name="pref_sslkey_info">Разрешить только подключения к указанному сертификату</string>
     <string name="pref_sslacceptall">Принимать все TLS-сертификаты</string>
+    <string name="pref_sslenable">Использовать TLS</string>
+    <string name="pref_local_sslenable">Использовать TLS в локальной сети</string>
+    <string name="pref_local_sslenable_info">Подключение с помощью HTTPS</string>
+    <string name="pref_sslkey">Пользовательское хеш-значение TLS (SHA-1)</string>
     <string name="pref_sslacceptall_info">Разрешить все подключения от любых хеш-значений</string>
+
     <string name="pref_background">Фоновые уведомления</string>
     <string name="pref_notifications_rss">Включить уведомления RSS-лент</string>
     <string name="pref_notifications_torrent">Включить уведомления торрентов</string>
@@ -318,6 +348,7 @@
     <string name="pref_export">Экспортировать настройки</string>
     <string name="pref_export_dialog">%1$s экспортирует настройки сервера (включая пароли), веб-поиска, RSS-лент и системы в файл формата JSON: %2$s</string>
     <string name="pref_export_success">Настройки успешно экспортированы</string>
+
     <string name="pref_help">Помощь по Transdroid</string>
     <string name="pref_sendlog">Отправить журнал ошибок</string>
     <string name="pref_sendlog_info">Обратиться в поддержку или сообщить об ошибке</string>
@@ -325,10 +356,12 @@
     <string name="pref_installhelp_info">Доступны по адресу www.transdroid.org/download</string>
     <string name="pref_changelog">Последние изменения</string>
     <string name="pref_about">О программе %1$s</string>
+
     <string name="pref_seedbox_addseedbox">Добавить сидбокс %1$s</string>
     <string name="pref_seedbox_client">Торрент-клиент</string>
     <string name="pref_seedbox_client_info">Клиент к которому будет выполнено подключение</string>
     <string name="pref_seedbox_server">Адрес сервера</string>
+    <string name="pref_seedbox_xirvikviaqr">Добавить Xirvik сидбокс с помощью QR кода</string>
     <string name="pref_seedbox_xirvikhint">Как eplus001.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint2">Как semixl001a.xirvik.com</string>
     <string name="pref_seedbox_xirvikhint3">Как desharedgbit001.xirvik.com</string>
@@ -340,6 +373,9 @@
         <item>12 часов</item>
         <item>1 день</item>
     </string-array>
+
+    <string name="permission_notifications">Transdroid нуждается в разрешении если вы хотите получать уведомления</string>
+
     <string name="error_httperror">Ошибка соединения. Проверьте подключение</string>
     <string name="error_jsonrequesterror">Внутренняя ошибка построения запроса</string>
     <string name="error_jsonresponseerror">Ошибка разбора ответа сервера. Пожалуйста, проверьте настройки</string>
@@ -349,7 +385,7 @@
     <string name="error_parsingrss">Ошибка при разборе RSS-ленты</string>
     <string name="error_invalid_url_form">Этот URL-адрес имеет ошибочный фрмат</string>
     <string name="error_invalid_search_url">URL-адрес поисковика является недопустимым:</string>
-    <string name="error_invalid_ip_or_hostname">Введен неверный IP адрес или имя хоста</string>
+    <string name="error_invalid_ip_or_hostname">Введен неверный IP адрес или хост</string>
     <string name="error_invalid_port_number">Номер порта должен быть числом</string>
     <string name="error_invalid_directory">Путь каталога заканчивается символами \"/\" или \"\"</string>
     <string name="error_invalid_timeout">Время ожидания должно быть заполнено и быть больше 0</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -276,11 +276,11 @@
     <string name="pref_ftppass">Пароль FTP(S)</string>
     <string name="pref_disableauth">Отключить аутентификацию</string>
     <string name="pref_disableauth_info">Не отправлять имя пользователя и пароль</string>
-    <string name="pref_sslenable">Использовать SSL</string>
+    <string name="pref_sslenable">Использовать TSL</string>
     <string name="pref_sslenable_info">Подключение с помощью HTTPS</string>
-    <string name="pref_sslkey">Пользовательское хеш-значение SSL (SHA-1)</string>
+    <string name="pref_sslkey">Пользовательское хеш-значение TSL (SHA-1)</string>
     <string name="pref_sslkey_info">Разрешить только подключения к указанному сертификату</string>
-    <string name="pref_sslacceptall">Принимать все SSL-сертификаты</string>
+    <string name="pref_sslacceptall">Принимать все TSL-сертификаты</string>
     <string name="pref_sslacceptall_info">Разрешить все подключения от любых хеш-значений</string>
     <string name="pref_background">Фоновые уведомления</string>
     <string name="pref_notifications_rss">Включить уведомления RSS-лент</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -275,11 +275,11 @@
     <string name="pref_ftppass">Geslo za FTP(S)</string>
     <string name="pref_disableauth">Onemogoči avtentikacijo</string>
     <string name="pref_disableauth_info">Ne pošlji uporabniškega imena in gesla</string>
-    <string name="pref_sslenable">Uporaba TSL</string>
+    <string name="pref_sslenable">Uporaba TLS</string>
     <string name="pref_sslenable_info">Poveži se z uporabo https</string>
-    <string name="pref_sslkey">Lastni TSL odtis (SHA-1 thumbprint)</string>
+    <string name="pref_sslkey">Lastni TLS odtis (SHA-1 thumbprint)</string>
     <string name="pref_sslkey_info">Dovoli le povezave na točno ta certifikat</string>
-    <string name="pref_sslacceptall">Sprejmi vse TSL certifikate</string>
+    <string name="pref_sslacceptall">Sprejmi vse TLS certifikate</string>
     <string name="pref_sslacceptall_info">Dovoli povezave s kateregakoli odtisa (thumbprinta)</string>
     <string name="pref_background">Obvestila iz ozadja</string>
     <string name="pref_notifications_rss">Omogoči RSS obvestila</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -275,11 +275,11 @@
     <string name="pref_ftppass">Geslo za FTP(S)</string>
     <string name="pref_disableauth">Onemogoči avtentikacijo</string>
     <string name="pref_disableauth_info">Ne pošlji uporabniškega imena in gesla</string>
-    <string name="pref_sslenable">Uporaba SSL</string>
+    <string name="pref_sslenable">Uporaba TSL</string>
     <string name="pref_sslenable_info">Poveži se z uporabo https</string>
-    <string name="pref_sslkey">Lastni SSL odtis (SHA-1 thumbprint)</string>
+    <string name="pref_sslkey">Lastni TSL odtis (SHA-1 thumbprint)</string>
     <string name="pref_sslkey_info">Dovoli le povezave na točno ta certifikat</string>
-    <string name="pref_sslacceptall">Sprejmi vse SSL certifikate</string>
+    <string name="pref_sslacceptall">Sprejmi vse TSL certifikate</string>
     <string name="pref_sslacceptall_info">Dovoli povezave s kateregakoli odtisa (thumbprinta)</string>
     <string name="pref_background">Obvestila iz ozadja</string>
     <string name="pref_notifications_rss">Omogoči RSS obvestila</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">FTP(S) lösenord</string>
     <string name="pref_disableauth">Inaktivera autentisering</string>
     <string name="pref_disableauth_info">Sänd inte användarnamn och lösenord</string>
-    <string name="pref_sslenable">Använd SSL</string>
+    <string name="pref_sslenable">Använd TSL</string>
     <string name="pref_sslenable_info">Anslut via https</string>
-    <string name="pref_sslkey">Anpassat SSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Anpassat TSL thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Tillåt endast anslutningar till detta särskilda certifikat</string>
-    <string name="pref_sslacceptall">Acceptera alla SSL-certifikat</string>
+    <string name="pref_sslacceptall">Acceptera alla TSL-certifikat</string>
     <string name="pref_sslacceptall_info">Tillåt alla anslutningar från alla thumbprints</string>
     <string name="pref_background">Bakgrundsnotifikationer</string>
     <string name="pref_notifications_rss">Aktivera RSS-notifikationer</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -259,11 +259,11 @@
     <string name="pref_ftppass">FTP(S) lösenord</string>
     <string name="pref_disableauth">Inaktivera autentisering</string>
     <string name="pref_disableauth_info">Sänd inte användarnamn och lösenord</string>
-    <string name="pref_sslenable">Använd TSL</string>
+    <string name="pref_sslenable">Använd TLS</string>
     <string name="pref_sslenable_info">Anslut via https</string>
-    <string name="pref_sslkey">Anpassat TSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Anpassat TLS thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Tillåt endast anslutningar till detta särskilda certifikat</string>
-    <string name="pref_sslacceptall">Acceptera alla TSL-certifikat</string>
+    <string name="pref_sslacceptall">Acceptera alla TLS-certifikat</string>
     <string name="pref_sslacceptall_info">Tillåt alla anslutningar från alla thumbprints</string>
     <string name="pref_background">Bakgrundsnotifikationer</string>
     <string name="pref_notifications_rss">Aktivera RSS-notifikationer</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -258,11 +258,11 @@
     <string name="pref_ftppass">FTP şifresi</string>
     <string name="pref_disableauth">Kimlik doğrulamasını devre dışı bırak</string>
     <string name="pref_disableauth_info">Kullanıcı adını ve şifreyi gönderme</string>
-    <string name="pref_sslenable">TSL kullan</string>
+    <string name="pref_sslenable">TLS kullan</string>
     <string name="pref_sslenable_info">HTTPS kullanarak bağlan</string>
-    <string name="pref_sslkey">Özel TSL parmak izi (SHA-1)</string>
+    <string name="pref_sslkey">Özel TLS parmak izi (SHA-1)</string>
     <string name="pref_sslkey_info">Sadece bu sertifika bağlantılarına izin ver</string>
-    <string name="pref_sslacceptall">Tüm TSL sertifikalarını kabul et</string>
+    <string name="pref_sslacceptall">Tüm TLS sertifikalarını kabul et</string>
     <string name="pref_sslacceptall_info">Herhangi bir parmak izinden gelen tüm bağlantılara izin ver</string>
     <string name="pref_background">Arka plan bildirimleri</string>
     <string name="pref_notifications_rss">RSS bildirimleri etkinleştir</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -258,11 +258,11 @@
     <string name="pref_ftppass">FTP şifresi</string>
     <string name="pref_disableauth">Kimlik doğrulamasını devre dışı bırak</string>
     <string name="pref_disableauth_info">Kullanıcı adını ve şifreyi gönderme</string>
-    <string name="pref_sslenable">SSL kullan</string>
+    <string name="pref_sslenable">TSL kullan</string>
     <string name="pref_sslenable_info">HTTPS kullanarak bağlan</string>
-    <string name="pref_sslkey">Özel SSL parmak izi (SHA-1)</string>
+    <string name="pref_sslkey">Özel TSL parmak izi (SHA-1)</string>
     <string name="pref_sslkey_info">Sadece bu sertifika bağlantılarına izin ver</string>
-    <string name="pref_sslacceptall">Tüm SSL sertifikalarını kabul et</string>
+    <string name="pref_sslacceptall">Tüm TSL sertifikalarını kabul et</string>
     <string name="pref_sslacceptall_info">Herhangi bir parmak izinden gelen tüm bağlantılara izin ver</string>
     <string name="pref_background">Arka plan bildirimleri</string>
     <string name="pref_notifications_rss">RSS bildirimleri etkinleştir</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -136,9 +136,9 @@
     <string name="pref_advanced">Розширені параметри</string>
     <string name="pref_disableauth">Вимкнути авторизацію</string>
     <string name="pref_disableauth_info">Не надсилати ім\'я користувача та пароль</string>
-    <string name="pref_sslenable">Використовувати TSL</string>
+    <string name="pref_sslenable">Використовувати TLS</string>
     <string name="pref_sslenable_info">З\'єднуватись через https</string>
-    <string name="pref_sslacceptall">Приймати всі TSL сертифікати</string>
+    <string name="pref_sslacceptall">Приймати всі TLS сертифікати</string>
     <string name="pref_notifysound">Звук</string>
     <string name="pref_notifyvibrate">Вібрація</string>
     <string-array name="pref_autorefresh_intervals">

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -136,9 +136,9 @@
     <string name="pref_advanced">Розширені параметри</string>
     <string name="pref_disableauth">Вимкнути авторизацію</string>
     <string name="pref_disableauth_info">Не надсилати ім\'я користувача та пароль</string>
-    <string name="pref_sslenable">Використовувати SSL</string>
+    <string name="pref_sslenable">Використовувати TSL</string>
     <string name="pref_sslenable_info">З\'єднуватись через https</string>
-    <string name="pref_sslacceptall">Приймати всі SSL сертифікати</string>
+    <string name="pref_sslacceptall">Приймати всі TSL сертифікати</string>
     <string name="pref_notifysound">Звук</string>
     <string name="pref_notifyvibrate">Вібрація</string>
     <string-array name="pref_autorefresh_intervals">

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -198,9 +198,9 @@
     <string name="pref_ftppass">Mật mã FPT(S)</string>
     <string name="pref_disableauth">Không dùng đăng nhập</string>
     <string name="pref_disableauth_info">Không gửi đi tên và mật khẩu</string>
-    <string name="pref_sslenable">Sử dụng SSL</string>
+    <string name="pref_sslenable">Sử dụng TSL</string>
     <string name="pref_sslenable_info">Kết nối bằng https</string>
-    <string name="pref_sslacceptall">Chấp nhận các chứng chỉ SSL</string>
+    <string name="pref_sslacceptall">Chấp nhận các chứng chỉ TSL</string>
     <string name="pref_background">Thông báo chạy nền</string>
     <string name="pref_notifications_rss">Bật thông báo RSS</string>
     <string name="pref_notifications_torrent">Bật thông báo torrent</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -198,9 +198,9 @@
     <string name="pref_ftppass">Mật mã FPT(S)</string>
     <string name="pref_disableauth">Không dùng đăng nhập</string>
     <string name="pref_disableauth_info">Không gửi đi tên và mật khẩu</string>
-    <string name="pref_sslenable">Sử dụng TSL</string>
+    <string name="pref_sslenable">Sử dụng TLS</string>
     <string name="pref_sslenable_info">Kết nối bằng https</string>
-    <string name="pref_sslacceptall">Chấp nhận các chứng chỉ TSL</string>
+    <string name="pref_sslacceptall">Chấp nhận các chứng chỉ TLS</string>
     <string name="pref_background">Thông báo chạy nền</string>
     <string name="pref_notifications_rss">Bật thông báo RSS</string>
     <string name="pref_notifications_torrent">Bật thông báo torrent</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -235,11 +235,11 @@
     <string name="pref_ftppass">FTP(S) 密码</string>
     <string name="pref_disableauth">禁止认证</string>
     <string name="pref_disableauth_info">不发送用户名和密码</string>
-    <string name="pref_sslenable">TSL连接</string>
+    <string name="pref_sslenable">TLS连接</string>
     <string name="pref_sslenable_info">使用https连接</string>
-    <string name="pref_sslkey">自定义TSL指纹 (SHA-1)</string>
+    <string name="pref_sslkey">自定义TLS指纹 (SHA-1)</string>
     <string name="pref_sslkey_info">只允许连接到这个特定的证书</string>
-    <string name="pref_sslacceptall">接受所有TSL证书</string>
+    <string name="pref_sslacceptall">接受所有TLS证书</string>
     <string name="pref_sslacceptall_info">允许来自任何指纹的所有连接</string>
     <string name="pref_background">后台通知</string>
     <string name="pref_notifications_rss">启用 RSS 通知</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -235,11 +235,11 @@
     <string name="pref_ftppass">FTP(S) 密码</string>
     <string name="pref_disableauth">禁止认证</string>
     <string name="pref_disableauth_info">不发送用户名和密码</string>
-    <string name="pref_sslenable">SSL连接</string>
+    <string name="pref_sslenable">TSL连接</string>
     <string name="pref_sslenable_info">使用https连接</string>
-    <string name="pref_sslkey">自定义SSL指纹 (SHA-1)</string>
+    <string name="pref_sslkey">自定义TSL指纹 (SHA-1)</string>
     <string name="pref_sslkey_info">只允许连接到这个特定的证书</string>
-    <string name="pref_sslacceptall">接受所有SSL证书</string>
+    <string name="pref_sslacceptall">接受所有TSL证书</string>
     <string name="pref_sslacceptall_info">允许来自任何指纹的所有连接</string>
     <string name="pref_background">后台通知</string>
     <string name="pref_notifications_rss">启用 RSS 通知</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,13 +305,13 @@
     <string name="pref_ftppass">FTP(S) password</string>
     <string name="pref_disableauth">Disable authentication</string>
     <string name="pref_disableauth_info">Don\'t send username and password</string>
-    <string name="pref_sslenable">Use SSL</string>
+    <string name="pref_sslenable">Use TSL</string>
     <string name="pref_sslenable_info">Connect using https</string>
-    <string name="pref_local_sslenable">Use SSL on local network</string>
+    <string name="pref_local_sslenable">Use TSL on local network</string>
     <string name="pref_local_sslenable_info">Connect using https</string>
-    <string name="pref_sslkey">Custom SSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Custom TSL thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Permit only connections to this specific certificate</string>
-    <string name="pref_sslacceptall">Accept all SSL certificates</string>
+    <string name="pref_sslacceptall">Accept all TSL certificates</string>
     <string name="pref_sslacceptall_info">Allow all connections from any thumbprint</string>
 
     <string name="pref_background">Background notifications</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,13 +305,13 @@
     <string name="pref_ftppass">FTP(S) password</string>
     <string name="pref_disableauth">Disable authentication</string>
     <string name="pref_disableauth_info">Don\'t send username and password</string>
-    <string name="pref_sslenable">Use TSL</string>
+    <string name="pref_sslenable">Use TLS</string>
     <string name="pref_sslenable_info">Connect using HTTPS</string>
-    <string name="pref_local_sslenable">Use TSL on local network</string>
+    <string name="pref_local_sslenable">Use TLS on local network</string>
     <string name="pref_local_sslenable_info">Connect using HTTPS</string>
-    <string name="pref_sslkey">Custom TSL thumbprint (SHA-1)</string>
+    <string name="pref_sslkey">Custom TLS thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Permit only connections to this specific certificate</string>
-    <string name="pref_sslacceptall">Accept all TSL certificates</string>
+    <string name="pref_sslacceptall">Accept all TLS certificates</string>
     <string name="pref_sslacceptall_info">Allow all connections from any thumbprint</string>
 
     <string name="pref_background">Background notifications</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="action_addall">Add all</string>
     <string name="action_addfromfile">From file</string>
     <string name="action_addfromurl">From URL</string>
-    <string name="action_scanbarcode">Scan barcode</string>
+    <string name="action_scanbarcode">Scan QR code</string>
     <string name="action_search">Search</string>
     <string name="action_refresh">Refresh</string>
     <string name="action_rss">RSS</string>
@@ -101,7 +101,7 @@
     <string name="navigation_invertselection">Invert selection</string>
     <string name="navigation_pickserver">Add torrent to&#8230;</string>
     <string name="navigation_url_hint" translatable="false">http://…</string>
-    <string name="navigation_rss_tabs_local">Transdroid</string>
+    <string name="navigation_rss_tabs_local" translatable="false">Transdroid</string>
     <string name="navigation_rss_tabs_remote">Server</string>
 
     <string name="status_status">STATUS: %1$s</string>
@@ -306,9 +306,9 @@
     <string name="pref_disableauth">Disable authentication</string>
     <string name="pref_disableauth_info">Don\'t send username and password</string>
     <string name="pref_sslenable">Use TSL</string>
-    <string name="pref_sslenable_info">Connect using https</string>
+    <string name="pref_sslenable_info">Connect using HTTPS</string>
     <string name="pref_local_sslenable">Use TSL on local network</string>
-    <string name="pref_local_sslenable_info">Connect using https</string>
+    <string name="pref_local_sslenable_info">Connect using HTTPS</string>
     <string name="pref_sslkey">Custom TSL thumbprint (SHA-1)</string>
     <string name="pref_sslkey_info">Permit only connections to this specific certificate</string>
     <string name="pref_sslacceptall">Accept all TSL certificates</string>

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,0 +1,5 @@
+files:
+  - source: /app/src/main/res/values/strings.xml
+    translation: /app/src/main/res/values-%android_code%/%original_file_name%
+  - source: /metadata/en-US/*.txt
+    translation: /metadata/%two_letters_code%/%original_file_name%


### PR DESCRIPTION
I noticed that some strings were translated and they aren't shown in the Crowdin.
It looks like we need to configure the crowdin.yaml with a path to original string and translations:
https://support.crowdin.com/developer/configuration-file/

Additionally I fixed some typos in the strings like SSL to TLS and TSL to TLS