### PR TITLE
feat(UI): Adding button to scroll to top quickly in torrent list view (fixes #587) 

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
@@ -21,7 +21,9 @@ import android.view.ActionMode;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AbsListView;
 import android.widget.AbsListView.MultiChoiceModeListener;
+import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -109,9 +111,10 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
     @ViewById
     protected TextView nosettingsText;
     @ViewById
-    protected TextView errorText;
-    @ViewById
+    protected TextView errorText;    @ViewById
     protected ProgressBar loadingProgress;
+    @ViewById
+    protected ImageButton scrollToTopButton;
     private MultiChoiceModeListener onTorrentsSelected = new MultiChoiceModeListener() {
 
         private SelectionManagerMode selectionManagerMode;
@@ -233,9 +236,7 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
             addmenuButton.setVisibility(View.VISIBLE);
         }
 
-    };
-
-    @AfterViews
+    };    @AfterViews
     protected void init() {
 
         // Load the requested sort order from the user settings
@@ -258,6 +259,59 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
         }
         nosettingsText.setText(getString(R.string.navigation_nosettings, getString(R.string.app_name)));
 
+        // Set up the scroll to top button
+        scrollToTopButton.setOnClickListener(v -> scrollToTop());
+        // Add scroll listener to show/hide scroll to top button
+        torrentsList.setOnScrollListener(new AbsListView.OnScrollListener() {
+
+            @Override
+            public void onScrollStateChanged(AbsListView view, int scrollState) {
+                // No implementation needed
+            }
+
+            @Override
+            public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+                // Show button when scrolling down, hide when at top
+                if (totalItemCount > 0) {
+                    if (firstVisibleItem > 1) {
+                        // User has scrolled down, show the button with animation
+                        if (scrollToTopButton.getVisibility() != View.VISIBLE) {
+                            scrollToTopButton.setVisibility(View.VISIBLE);
+                            scrollToTopButton.startAnimation(android.view.animation.AnimationUtils.loadAnimation(
+                                    getActivity(), R.anim.fade_in));
+                        }
+                    } else {
+                        // User is at the top, hide the button with animation
+                        if (scrollToTopButton.getVisibility() == View.VISIBLE) {
+                            android.view.animation.Animation fadeOut = android.view.animation.AnimationUtils.loadAnimation(
+                                    getActivity(), R.anim.fade_out);
+                            fadeOut.setAnimationListener(new android.view.animation.Animation.AnimationListener() {
+                                @Override
+                                public void onAnimationStart(android.view.animation.Animation animation) {}
+
+                                @Override
+                                public void onAnimationEnd(android.view.animation.Animation animation) {
+                                    scrollToTopButton.setVisibility(View.GONE);
+                                }
+
+                                @Override
+                                public void onAnimationRepeat(android.view.animation.Animation animation) {}
+                            });
+                            scrollToTopButton.startAnimation(fadeOut);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Scrolls the torrents list to the top position
+     */
+    private void scrollToTop() {
+        if (torrentsList != null) {
+            torrentsList.smoothScrollToPosition(0);
+        }
     }
 
     /**
@@ -472,9 +526,7 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
         } else {
             updateViewVisibility();
         }
-    }
-
-    private void updateViewVisibility() {
+    }    private void updateViewVisibility() {
         if (!hasAConnection) {
             return;
         }
@@ -486,6 +538,11 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
         loadingProgress.setVisibility(!hasError && isLoading ? View.VISIBLE : View.GONE);
         emptyText.setVisibility(!hasError && !isLoading && isEmpty ? View.VISIBLE : View.GONE);
         swipeRefreshLayout.setEnabled(true);
+
+        // If list is not visible, ensure scroll to top button is also hidden
+        if (torrentsList.getVisibility() != View.VISIBLE) {
+            scrollToTopButton.setVisibility(View.GONE);
+        }
     }
 
     /**

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0" />

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />

--- a/app/src/main/res/drawable/ic_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_up.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/app/src/main/res/drawable/scroll_to_top_background.xml
+++ b/app/src/main/res/drawable/scroll_to_top_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/colorAccent" />
+</shape>

--- a/app/src/main/res/layout/fragment_torrents.xml
+++ b/app/src/main/res/layout/fragment_torrents.xml
@@ -37,6 +37,20 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ImageButton
+        android:id="@+id/scroll_to_top_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:background="@drawable/scroll_to_top_background"
+        android:contentDescription="@string/action_scroll_to_top"
+        android:elevation="6dp"
+        android:src="@drawable/ic_arrow_up"
+        android:translationY="-16dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <ProgressBar
         android:id="@+id/loading_progress"
         android:layout_width="128dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="action_removesettings">Remove settings</string>
     <string name="action_visitwebsite">Visit transdroid.org</string>
     <string name="action_close">Close</string>
+    <string name="action_scroll_to_top">Scroll to top</string>
 
     <string name="navigation_opendrawer">Select server and filter</string>
     <string name="navigation_closedrawer">Close filters list</string>


### PR DESCRIPTION
## Purpose
When using Transdroid with a Torrent server that has a large number of torrents (e.g., 3000+), navigating the torrent list can be inefficient. Specifically, if a user selects an active torrent and then changes the sort order (e.g., "all order by size"), the list often remains scrolled to the middle. This makes it difficult to quickly view torrents at the beginning of the newly sorted list, such as the largest torrents when sorting by size. (fixes #587) 

## Solution
Create a "Scroll to top" button which allows users to easily scroll back to the top of the torrent list when they've scrolled down. The button appears with a smooth fade-in animation when scrolling down and disappears with a fade-out when returning to the top of the list.

1. Created a vector drawable icon for the up arrow (`ic_arrow_up.xml`)
2. Created a circular background for the button (`scroll_to_top_background.xml`) 
3. Added the button to the fragment layout (fragment_torrents.xml)
4. Added animation files for smooth transitions (`fade_in.xml` and `fade_out.xml`)
5. Updated the TorrentsFragment Java class to:
   - Add a reference to the button
   - Implement a scroll listener that shows/hides the button as needed
   - Add a scroll to top method that's called when the button is clicked
   - Update the visibility management for proper showing/hiding of the button

## Testing
Demo Link: https://drive.google.com/file/d/1vbRJz1j2XKxQ-S9aIArYCGdrt9AgQiVH/view?usp=drivesdk
1. Empty list -> no button
2. List expanded upto non scrollable view -> no button
3. List expanded with scroll bar -> button visible -> click takes to top
4. Opening detail view -> button visible if scroll bar exist
5. Check sorting and filtering functionality with no side effects