### PR TITLE
qBittorrent: add mappings for forced states

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
@@ -891,9 +891,12 @@ public class QBittorrentAdapter implements IDaemonAdapter {
             case "downloading":
             case "metaDL":
             case "stalledDL":
+            case "forcedDL":
+            case "forcedMetaDL":
                 return TorrentStatus.Downloading;
             case "uploading":
             case "stalledUP":
+            case "forcedUP":
                 return TorrentStatus.Seeding;
             case "pausedDL":
             case "pausedUP":


### PR DESCRIPTION
Otherwise, these torrents will be displayed with unknown status.

Full list of states:

https://github.com/qbittorrent/qBittorrent/blob/163f6831868488f926db7f9404858c2ec69d0542/src/webui/api/serialize/serialize_torrent.cpp#L44-L88