### PR TITLE
qbittorrent: accept QBT_SID_ cookies

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
@@ -205,12 +205,17 @@ public class QBittorrentAdapter implements IDaemonAdapter {
         }
         List<Cookie> cookies = httpclient.getCookieStore().getCookies();
         for (Cookie c : cookies) {
-            if (c.getName().equals("SID")) {
+            if (isSessionCookie(c)) {
                 // And here it is!  Okay, no need authenticate again.
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean isSessionCookie(Cookie cookie) {
+        String name = cookie.getName();
+        return name.equals("SID") || name.startsWith("QBT_SID_");
     }
 
     @Override


### PR DESCRIPTION
Allow QBT_SID_* cookies in qBittorrent.  [The name was changed from SID in qBittorrent  5.2](https://github.com/qbittorrent/qBittorrent/commit/753fb80e9bf4aa96dbb929f16d29c0156069a2c9).

Fixes https://github.com/erickok/transdroid/issues/692
