### PR TITLE
Feature - Torrent details (files/peers/trackers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Some code/libraries/resources are used in the project:
 *  [android-ColorPickerPreference](https://github.com/attenzione/android-ColorPickerPreference)
     Daniel Nilsson and Sergey Margaritov
     Apache License, Version 2.0
+*  [MaxMind DB Reader for Java](https://github.com/maxmind/MaxMind-DB-Reader-java)
+    MaxMind, Inc.
+    Apache License, Version 2.0
+*  [IP66 GeoIP database](https://ip66.dev/) (optional, downloaded in-app for peer country flags)
+    ip66.dev
 *  RssParser ([learning-android](https://github.com/tanepiper/learning-android))
     Tane Piper
     Public Domain

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,6 +100,12 @@ dependencies {
     implementation 'androidx.work:work-runtime:2.9.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel:2.6.2"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2"
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+
+    // GeoIP country lookup for the peer list. NOTE: maxmind-db 4.x requires Java 17; this project
+    // targets Java 8, so we pin to the last Java-8 compatible line (2.x), whose generic decoder
+    // (Reader.get(InetAddress, Class)) returns the record as a nested Map.
+    implementation 'com.maxmind.db:maxmind-db:2.1.0'
 
     annotationProcessor 'org.androidannotations:androidannotations:4.8.0'
     annotationProcessor 'org.androidannotations:ormlite:4.8.0'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,3 +2,7 @@
 
 -keep class org.transdroid.core.gui.log.ErrorLogEntry { *; }
 -dontwarn javax.persistence.**
+
+# GeoIP (maxmind-db), used for peer country lookups.
+-keep class com.maxmind.db.** { *; }
+-dontwarn com.maxmind.db.**

--- a/app/src/main/java/org/transdroid/core/app/settings/SystemSettings.java
+++ b/app/src/main/java/org/transdroid/core/app/settings/SystemSettings.java
@@ -24,6 +24,7 @@ import androidx.preference.PreferenceManager;
 import org.androidannotations.annotations.EBean;
 import org.androidannotations.annotations.EBean.Scope;
 import org.androidannotations.annotations.RootContext;
+import org.transdroid.daemon.PeersSortBy;
 
 import java.util.Date;
 
@@ -56,6 +57,16 @@ public class SystemSettings {
         return Integer.parseInt(prefs.getString("system_autorefresh", "0")) * 1000;
     }
 
+    /**
+     * Returns the interval at which the torrent details screen (files, peers, trackers) should
+     * automatically refresh while a torrent is being viewed.
+     *
+     * @return The selected interval in milliseconds, or 0 if details auto-refresh is disabled
+     */
+    public long getDetailsRefreshIntervalMilliseconds() {
+        return Integer.parseInt(prefs.getString("details_autorefresh", "0")) * 1000;
+    }
+
     public boolean checkForUpdates() {
         return prefs.getBoolean("system_checkupdates", true);
     }
@@ -66,6 +77,15 @@ public class SystemSettings {
 
     public boolean useDarkTheme() {
         return prefs.getBoolean("system_usedarktheme", false);
+    }
+
+    /**
+     * Returns the criterion by which a torrent's connected peers should be sorted in the details view.
+     *
+     * @return The selected peer sort order, defaulting to total (down + up) speed
+     */
+    public PeersSortBy getPeerSortBy() {
+        return PeersSortBy.fromValue(prefs.getString("peer_sort", PeersSortBy.TotalSpeed.getValue()));
     }
 
     /**

--- a/app/src/main/java/org/transdroid/core/gui/DetailsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/DetailsActivity.java
@@ -20,6 +20,8 @@ import android.annotation.TargetApi;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
@@ -45,6 +47,7 @@ import org.androidannotations.annotations.UiThread;
 import org.androidannotations.annotations.ViewById;
 import org.transdroid.R;
 import org.transdroid.core.app.settings.ApplicationSettings;
+import org.transdroid.core.app.settings.SystemSettings;
 import org.transdroid.core.app.settings.ServerSetting;
 import org.transdroid.core.app.settings.SettingsUtils;
 import org.transdroid.core.gui.lists.LocalTorrent;
@@ -55,6 +58,7 @@ import org.transdroid.core.gui.navigation.RefreshableActivity;
 import org.transdroid.core.service.ConnectivityHelper;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.IDaemonAdapter;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
@@ -67,6 +71,8 @@ import org.transdroid.daemon.task.GetFileListTask;
 import org.transdroid.daemon.task.GetFileListTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.PauseTask;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.ResumeTask;
@@ -111,18 +117,69 @@ public class DetailsActivity extends AppCompatActivity implements TorrentTasksEx
     protected ConnectivityHelper connectivityHelper;
     @Bean
     protected ApplicationSettings applicationSettings;
+    @Bean
+    protected SystemSettings systemSettings;
     // Details view components
     @ViewById
     protected Toolbar selectionToolbar;
     @FragmentById(R.id.torrentdetails_fragment)
     protected DetailsFragment fragmentDetails;
     private IDaemonAdapter currentConnection = null;
+    // Optional interval-based refresh of the details screen (files, peers, trackers)
+    public boolean stopRefresh = false;
+    private Handler autoRefreshHandler = null;
+    private Runnable autoRefreshRunnable = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         SettingsUtils.applyDayNightTheme(this);
         super.onCreate(savedInstanceState);
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        startAutoRefresh();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        stopAutoRefresh();
+    }
+
+    /**
+     * Starts interval-based refreshing of the details screen, if enabled in the settings and not
+     * currently suppressed (e.g. during a multi-select action). Each tick silently re-fetches the
+     * torrent (which cascades into refreshing its details, files and peers).
+     */
+    public void startAutoRefresh() {
+        long interval = systemSettings.getDetailsRefreshIntervalMilliseconds();
+        if (autoRefreshHandler != null || stopRefresh || interval == 0 || torrent == null) {
+            return;
+        }
+        autoRefreshHandler = new Handler(Looper.getMainLooper());
+        autoRefreshRunnable = new Runnable() {
+            @Override
+            public void run() {
+                // Silent refresh: no loading spinner, just re-fetch data in place
+                refreshTorrent();
+                long next = systemSettings.getDetailsRefreshIntervalMilliseconds();
+                if (next > 0 && autoRefreshHandler != null) {
+                    autoRefreshHandler.postDelayed(this, next);
+                }
+            }
+        };
+        autoRefreshHandler.postDelayed(autoRefreshRunnable, interval);
+    }
+
+    public void stopAutoRefresh() {
+        if (autoRefreshHandler != null && autoRefreshRunnable != null) {
+            autoRefreshHandler.removeCallbacks(autoRefreshRunnable);
+        }
+        autoRefreshHandler = null;
+        autoRefreshRunnable = null;
     }
 
     @AfterViews
@@ -179,6 +236,7 @@ public class DetailsActivity extends AppCompatActivity implements TorrentTasksEx
         refreshTorrent();
         refreshTorrentDetails(torrent);
         refreshTorrentFiles(torrent);
+        refreshTorrentPeers(torrent);
     }
 
     @Background
@@ -214,6 +272,21 @@ public class DetailsActivity extends AppCompatActivity implements TorrentTasksEx
         DaemonTaskResult result = GetFileListTask.create(currentConnection, torrent).execute(log);
         if (result instanceof GetFileListTaskSuccessResult) {
             onTorrentFilesRetrieved(torrent, ((GetFileListTaskSuccessResult) result).getFiles());
+        } else {
+            onCommunicationError((DaemonTaskFailureResult) result, false);
+        }
+    }
+
+    @Background
+    @Override
+    public void refreshTorrentPeers(Torrent torrent) {
+        if (currentConnection == null) return;
+        if (!Daemon.supportsExtraPeers(torrent.getDaemon())) {
+            return;
+        }
+        DaemonTaskResult result = GetTorrentPeersTask.create(currentConnection, torrent).execute(log);
+        if (result instanceof GetTorrentPeersTaskSuccessResult) {
+            onTorrentPeersRetrieved(torrent, ((GetTorrentPeersTaskSuccessResult) result).getPeers());
         } else {
             onCommunicationError((DaemonTaskFailureResult) result, false);
         }
@@ -398,6 +471,13 @@ public class DetailsActivity extends AppCompatActivity implements TorrentTasksEx
         // Update the details fragment with the newly retrieved list of files
         if (fragmentDetails.isResumed())
             fragmentDetails.updateTorrentFiles(torrent, new ArrayList<>(torrentFiles));
+    }
+
+    @UiThread
+    protected void onTorrentPeersRetrieved(Torrent torrent, List<Peer> torrentPeers) {
+        // Update the details fragment with the newly retrieved list of peers
+        if (fragmentDetails.isResumed())
+            fragmentDetails.updateTorrentPeers(torrent, new ArrayList<>(torrentPeers));
     }
 
     @UiThread

--- a/app/src/main/java/org/transdroid/core/gui/DetailsFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/DetailsFragment.java
@@ -27,6 +27,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AbsListView.MultiChoiceModeListener;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -34,23 +35,29 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.ActionMenuView;
 import androidx.fragment.app.Fragment;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.viewpager2.widget.ViewPager2;
 
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
 import com.nispok.snackbar.Snackbar;
 import com.nispok.snackbar.SnackbarManager;
 import com.nispok.snackbar.enums.SnackbarType;
 
 import org.androidannotations.annotations.AfterViews;
+import org.androidannotations.annotations.Bean;
 import org.androidannotations.annotations.Click;
 import org.androidannotations.annotations.EFragment;
 import org.androidannotations.annotations.InstanceState;
-import org.androidannotations.annotations.ItemClick;
 import org.androidannotations.annotations.OptionsItem;
 import org.androidannotations.annotations.ViewById;
 import org.transdroid.R;
 import org.transdroid.core.app.settings.ServerSetting;
-import org.transdroid.core.gui.lists.DetailsAdapter;
-import org.transdroid.core.gui.lists.SimpleListItemAdapter;
+import org.transdroid.core.app.settings.SystemSettings;
+import org.transdroid.core.gui.lists.DetailsPagerAdapter;
+import org.transdroid.core.gui.lists.GeoIpHelper;
+import org.transdroid.core.gui.lists.PiecesMapView;
+import org.transdroid.core.gui.lists.TorrentDetailsView;
+import org.transdroid.core.gui.lists.TorrentDetailsView_;
 import org.transdroid.core.gui.navigation.Label;
 import org.transdroid.core.gui.navigation.NavigationHelper_;
 import org.transdroid.core.gui.navigation.RefreshableActivity;
@@ -62,10 +69,13 @@ import org.transdroid.core.gui.navigation.SetStorageLocationDialog.OnStorageLoca
 import org.transdroid.core.gui.navigation.SetTrackersDialog;
 import org.transdroid.core.gui.navigation.SetTrackersDialog.OnTrackersUpdatedListener;
 import org.transdroid.daemon.Daemon;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,6 +101,8 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
     @InstanceState
     protected ArrayList<TorrentFile> torrentFiles = null;
     @InstanceState
+    protected ArrayList<Peer> torrentPeers = null;
+    @InstanceState
     protected ArrayList<Label> currentLabels = null;
     @InstanceState
     protected boolean isLoadingTorrent = false;
@@ -104,13 +116,25 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
     @ViewById(R.id.contextual_menu)
     protected ActionMenuView contextualMenu;
     @ViewById
-    protected SwipeRefreshLayout swipeRefreshLayout;
+    protected View detailsContent;
     @ViewById
-    protected ListView detailsList;
+    protected LinearLayout detailsHeader;
+    @ViewById
+    protected TabLayout detailsTabs;
+    @ViewById
+    protected ViewPager2 detailsPager;
     @ViewById
     protected TextView emptyText, errorText;
     @ViewById
     protected ProgressBar loadingProgress;
+    @Bean
+    protected GeoIpHelper geoIpHelper;
+    @Bean
+    protected SystemSettings systemSettings;
+    private DetailsPagerAdapter pagerAdapter = null;
+    private ListView filesList = null;
+    private TorrentDetailsView torrentDetailsView = null;
+    private PiecesMapView piecesMapView = null;
     private ServerSetting currentServerSettings = null;
     private MultiChoiceModeListener onDetailsSelected = new MultiChoiceModeListener() {
 
@@ -126,7 +150,7 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
             getActivity().getMenuInflater().inflate(R.menu.fragment_details_cab_main, contextualMenu.getMenu());
             Context themedContext = ((AppCompatActivity) getActivity()).getSupportActionBar().getThemedContext();
             mode.getMenuInflater().inflate(R.menu.fragment_details_cab_secondary, menu);
-            selectionManagerMode = new SelectionManagerMode(themedContext, detailsList, R.plurals.navigation_filesselected);
+            selectionManagerMode = new SelectionManagerMode(themedContext, filesList, R.plurals.navigation_filesselected);
             selectionManagerMode.setOnlyCheckClass(TorrentFile.class);
             selectionManagerMode.onCreateActionMode(mode, menu);
             return true;
@@ -139,6 +163,10 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
             if (getActivity() != null && getActivity() instanceof TorrentsActivity) {
                 ((TorrentsActivity) getActivity()).stopRefresh = true;
                 ((TorrentsActivity) getActivity()).stopAutoRefresh();
+            }
+            if (getActivity() instanceof DetailsActivity) {
+                ((DetailsActivity) getActivity()).stopRefresh = true;
+                ((DetailsActivity) getActivity()).stopAutoRefresh();
             }
             boolean filePaths = currentServerSettings != null && Daemon.supportsFilePaths(currentServerSettings.getType());
             contextualMenu.getMenu().findItem(R.id.action_download).setVisible(filePaths);
@@ -156,10 +184,10 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
 
             // Get checked torrents
             List<TorrentFile> checked = new ArrayList<>();
-            for (int i = 0; i < detailsList.getCheckedItemPositions().size(); i++) {
-                if (detailsList.getCheckedItemPositions().valueAt(i) && i < detailsList.getAdapter().getCount() &&
-                        detailsList.getAdapter().getItem(detailsList.getCheckedItemPositions().keyAt(i)) instanceof TorrentFile) {
-                    checked.add((TorrentFile) detailsList.getAdapter().getItem(detailsList.getCheckedItemPositions().keyAt(i)));
+            for (int i = 0; i < filesList.getCheckedItemPositions().size(); i++) {
+                if (filesList.getCheckedItemPositions().valueAt(i) && i < filesList.getAdapter().getCount() &&
+                        filesList.getAdapter().getItem(filesList.getCheckedItemPositions().keyAt(i)) instanceof TorrentFile) {
+                    checked.add((TorrentFile) filesList.getAdapter().getItem(filesList.getCheckedItemPositions().keyAt(i)));
                 }
             }
 
@@ -269,6 +297,10 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
                 ((TorrentsActivity) getActivity()).stopRefresh = false;
                 ((TorrentsActivity) getActivity()).startAutoRefresh();
             }
+            if (getActivity() instanceof DetailsActivity) {
+                ((DetailsActivity) getActivity()).stopRefresh = false;
+                ((DetailsActivity) getActivity()).startAutoRefresh();
+            }
             selectionManagerMode.onDestroyActionMode(mode);
             contextualMenu.setVisibility(View.GONE);
             detailsMenu.setVisibility(View.VISIBLE);
@@ -290,17 +322,43 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
 
         createMenuOptions();
 
-        // Set up details adapter (itself containing the actual lists to show), which allows multi-select and fast
-        // scrolling
-        detailsList.setAdapter(new DetailsAdapter(getActivity()));
-        detailsList.setMultiChoiceModeListener(onDetailsSelected);
-        detailsList.setFastScrollEnabled(true);
-        if (getActivity() != null && getActivity() instanceof RefreshableActivity) {
-            swipeRefreshLayout.setOnRefreshListener(() -> {
+        // Build the fixed summary header (torrent stats and an optional pieces map)
+        torrentDetailsView = TorrentDetailsView_.build(getActivity());
+        torrentDetailsView.setVisibility(View.GONE);
+        detailsHeader.addView(torrentDetailsView);
+        piecesMapView = new PiecesMapView(getActivity());
+        piecesMapView.setVisibility(View.GONE);
+        detailsHeader.addView(piecesMapView);
+
+        // Set up the swipeable Files / Peers / Trackers pager below the header
+        Runnable refresh = () -> {
+            if (getActivity() instanceof RefreshableActivity) {
                 ((RefreshableActivity) getActivity()).refreshScreen();
-                swipeRefreshLayout.setRefreshing(false); // Use our custom indicator
-            });
-        }
+            }
+        };
+        pagerAdapter = new DetailsPagerAdapter(getActivity(), geoIpHelper, refresh);
+        detailsPager.setAdapter(pagerAdapter);
+        detailsPager.setOffscreenPageLimit(2); // Keep all three pages alive
+        new TabLayoutMediator(detailsTabs, detailsPager, (tab, position) -> {
+            switch (position) {
+                case DetailsPagerAdapter.PAGE_PEERS:
+                    tab.setText(R.string.status_peers);
+                    break;
+                case DetailsPagerAdapter.PAGE_TRACKERS:
+                    tab.setText(R.string.status_trackers);
+                    break;
+                case DetailsPagerAdapter.PAGE_FILES:
+                default:
+                    tab.setText(R.string.status_files);
+                    break;
+            }
+        }).attach();
+
+        // The Files list keeps the multi-select priority contextual action bar
+        filesList = pagerAdapter.getFilesList();
+        filesList.setMultiChoiceModeListener(onDetailsSelected);
+        filesList.setFastScrollEnabled(true);
+        filesList.setOnItemClickListener((parent, view, position, id) -> filesList.setItemChecked(position, false));
 
         // Restore the fragment state (on orientation changes et al.)
         if (torrent != null) {
@@ -311,6 +369,9 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
         }
         if (torrent != null && torrentFiles != null) {
             updateTorrentFiles(torrent, torrentFiles);
+        }
+        if (torrent != null && torrentPeers != null) {
+            updateTorrentPeers(torrent, torrentPeers);
         }
 
     }
@@ -328,20 +389,27 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
         this.torrent = newTorrent;
         this.torrentId = newTorrent.getUniqueID();
         this.hasCriticalError = false;
-        ((DetailsAdapter) detailsList.getAdapter()).updateTorrent(newTorrent);
-        // Make the list (with details header) visible
-        detailsList.setVisibility(View.VISIBLE);
+        torrentDetailsView.update(newTorrent);
+        torrentDetailsView.setVisibility(newTorrent == null ? View.GONE : View.VISIBLE);
+        // Make the content (header + swipeable pages) visible
+        detailsContent.setVisibility(View.VISIBLE);
         emptyText.setVisibility(View.GONE);
         errorText.setVisibility(View.GONE);
         loadingProgress.setVisibility(View.GONE);
         // Also update the available actions in the action bar
         updateMenuOptions();
-        // Refresh the detailed statistics (errors) and list of files
+        // Refresh the detailed statistics (trackers), peers and list of files
         torrentDetails = null;
         torrentFiles = null;
+        torrentPeers = null;
         if (getTasksExecutor() != null) {
             getTasksExecutor().refreshTorrentDetails(torrent);
             getTasksExecutor().refreshTorrentFiles(torrent);
+            if (Daemon.supportsExtraPeers(torrent.getDaemon())) {
+                getTasksExecutor().refreshTorrentPeers(torrent);
+            } else {
+                updateTorrentPeers(torrent, new ArrayList<>());
+            }
         }
     }
 
@@ -357,12 +425,25 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
             return;
         }
         this.torrentDetails = newTorrentDetails;
-        ((DetailsAdapter) detailsList.getAdapter())
-                .updateTrackers(SimpleListItemAdapter.SimpleStringItem.wrapStringsList(newTorrentDetails.getTrackers()));
-        ((DetailsAdapter) detailsList.getAdapter())
-                .updateErrors(SimpleListItemAdapter.SimpleStringItem.wrapStringsList(newTorrentDetails.getErrors()));
-        ((DetailsAdapter) detailsList.getAdapter())
-                .updatePieces(newTorrentDetails.getPieces());
+
+        // Prefer the structured tracker details; fall back to the plain tracker URLs (status unknown)
+        List<Tracker> trackers = newTorrentDetails.getTrackerDetails();
+        if ((trackers == null || trackers.isEmpty()) && newTorrentDetails.getTrackers() != null) {
+            trackers = new ArrayList<>();
+            for (String url : newTorrentDetails.getTrackers()) {
+                trackers.add(new Tracker(url, TrackerStatus.UNKNOWN, null));
+            }
+        }
+        pagerAdapter.setTrackers(trackers);
+
+        // Update the optional pieces map in the fixed header
+        List<Integer> pieces = newTorrentDetails.getPieces();
+        if (pieces == null || pieces.isEmpty()) {
+            piecesMapView.setVisibility(View.GONE);
+        } else {
+            piecesMapView.setPieces(pieces);
+            piecesMapView.setVisibility(View.VISIBLE);
+        }
     }
 
     /**
@@ -378,7 +459,24 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
         }
         Collections.sort(newTorrentFiles);
         this.torrentFiles = newTorrentFiles;
-        ((DetailsAdapter) detailsList.getAdapter()).updateTorrentFiles(newTorrentFiles);
+        pagerAdapter.setFiles(newTorrentFiles);
+    }
+
+    /**
+     * Updates the list adapter to show a new list of connected peers, replacing the old peers list.
+     *
+     * @param checkTorrent    The torrent for which the peers were retrieved
+     * @param newTorrentPeers The new, updated list of peer objects
+     */
+    public void updateTorrentPeers(Torrent checkTorrent, ArrayList<Peer> newTorrentPeers) {
+        // Check if these are actually the peers of the torrent we are now showing
+        if (torrentId == null || !torrentId.equals(checkTorrent.getUniqueID())) {
+            return;
+        }
+        Collections.sort(newTorrentPeers, systemSettings.getPeerSortBy().comparator());
+        this.torrentPeers = newTorrentPeers;
+        boolean supported = currentServerSettings == null || Daemon.supportsExtraPeers(currentServerSettings.getType());
+        pagerAdapter.setPeers(newTorrentPeers, supported);
     }
 
     /**
@@ -414,14 +512,25 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
      * Clear the screen by fully clearing the internal merge list (with header and other lists)
      */
     public void clear() {
-        detailsList.setAdapter(new DetailsAdapter(getActivity()));
-        detailsList.setVisibility(View.GONE);
+        if (pagerAdapter != null) {
+            pagerAdapter.setFiles(new ArrayList<>());
+            pagerAdapter.setPeers(new ArrayList<>(), true);
+            pagerAdapter.setTrackers(new ArrayList<>());
+        }
+        if (torrentDetailsView != null) {
+            torrentDetailsView.setVisibility(View.GONE);
+        }
+        if (piecesMapView != null) {
+            piecesMapView.setVisibility(View.GONE);
+        }
+        detailsContent.setVisibility(View.GONE);
         emptyText.setVisibility(!isLoadingTorrent && !hasCriticalError ? View.VISIBLE : View.GONE);
         errorText.setVisibility(!isLoadingTorrent && hasCriticalError ? View.VISIBLE : View.GONE);
         loadingProgress.setVisibility(isLoadingTorrent ? View.VISIBLE : View.GONE);
         torrent = null;
         torrentDetails = null;
         torrentFiles = null;
+        torrentPeers = null;
     }
 
     /**
@@ -437,11 +546,6 @@ public class DetailsFragment extends Fragment implements OnTrackersUpdatedListen
         if (isLoading || hasCriticalError) {
             clear();
         }
-    }
-
-    @ItemClick(resName = "details_list")
-    protected void detailsListClicked(int position) {
-        detailsList.setItemChecked(position, false);
     }
 
     public void createMenuOptions() {

--- a/app/src/main/java/org/transdroid/core/gui/TorrentTasksExecutor.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentTasksExecutor.java
@@ -54,5 +54,7 @@ public interface TorrentTasksExecutor {
 
     void refreshTorrentFiles(Torrent torrent);
 
+    void refreshTorrentPeers(Torrent torrent);
+
     void updatePriority(Torrent torrent, List<TorrentFile> files, Priority priority);
 }

--- a/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
@@ -97,6 +97,7 @@ import org.transdroid.core.widget.ListWidgetProvider;
 import org.transdroid.daemon.Daemon;
 import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.IDaemonAdapter;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
@@ -115,6 +116,8 @@ import org.transdroid.daemon.task.GetStatsTask;
 import org.transdroid.daemon.task.GetStatsTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.PauseTask;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.ResumeTask;
@@ -1092,6 +1095,25 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
     }
 
     @Background
+    @Override
+    public void refreshTorrentPeers(Torrent torrent) {
+        if (!Daemon.supportsExtraPeers(currentConnection.getType())) {
+            return;
+        }
+        String startConnectionId = currentConnection.getSettings().getIdString();
+        DaemonTaskResult result = GetTorrentPeersTask.create(currentConnection, torrent).execute(log);
+        if (!startConnectionId.equals(currentConnection.getSettings().getIdString())) {
+            // During the command execution the user changed the server, so we are no longer interested in the result
+            return;
+        }
+        if (result instanceof GetTorrentPeersTaskSuccessResult) {
+            onTorrentPeersRetrieved(torrent, ((GetTorrentPeersTaskSuccessResult) result).getPeers());
+        } else {
+            onCommunicationError((DaemonTaskFailureResult) result, false);
+        }
+    }
+
+    @Background
     protected void getAdditionalStats() {
         String startConnectionId = currentConnection.getSettings().getIdString();
         DaemonTaskResult result = GetStatsTask.create(currentConnection).execute(log);
@@ -1500,6 +1522,14 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
         // Update the details fragment with the newly retrieved list of files
         if (fragmentDetails != null && fragmentDetails.isResumed()) {
             fragmentDetails.updateTorrentFiles(torrent, new ArrayList<>(torrentFiles));
+        }
+    }
+
+    @UiThread
+    protected void onTorrentPeersRetrieved(Torrent torrent, List<Peer> torrentPeers) {
+        // Update the details fragment with the newly retrieved list of peers
+        if (fragmentDetails != null && fragmentDetails.isResumed()) {
+            fragmentDetails.updateTorrentPeers(torrent, new ArrayList<>(torrentPeers));
         }
     }
 

--- a/app/src/main/java/org/transdroid/core/gui/lists/DetailsPagerAdapter.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/DetailsPagerAdapter.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import org.transdroid.R;
+import org.transdroid.daemon.Peer;
+import org.transdroid.daemon.TorrentFile;
+import org.transdroid.daemon.Tracker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link ViewPager2} adapter that hosts the three swipeable detail pages (Files, Peers and
+ * Trackers), each a {@link ListView} wrapped in a {@link SwipeRefreshLayout}. The page views are
+ * built once and reused, so the hosting fragment can keep stable references to push data and attach
+ * the multi-select contextual action bar to the Files list.
+ *
+ * @author Eric Kok
+ */
+public class DetailsPagerAdapter extends RecyclerView.Adapter<DetailsPagerAdapter.PageViewHolder> {
+
+    public static final int PAGE_FILES = 0;
+    public static final int PAGE_PEERS = 1;
+    public static final int PAGE_TRACKERS = 2;
+    private static final int PAGE_COUNT = 3;
+
+    private final View[] pages = new View[PAGE_COUNT];
+    private final ListView filesList;
+    private final ListView peersList;
+    private final ListView trackersList;
+    private final TextView peersEmpty;
+    private final FilesAdapter filesAdapter;
+    private final PeersAdapter peersAdapter;
+    private final TrackersAdapter trackersAdapter;
+
+    public DetailsPagerAdapter(Context context, GeoIpHelper geoIpHelper, Runnable refreshCallback) {
+
+        LayoutInflater inflater = LayoutInflater.from(context);
+
+        // Files page (the only multi-selectable one, to preserve the priority CAB)
+        pages[PAGE_FILES] = inflater.inflate(R.layout.page_details_list, null);
+        filesList = pages[PAGE_FILES].findViewById(R.id.page_list);
+        TextView filesEmpty = pages[PAGE_FILES].findViewById(R.id.page_empty);
+        filesEmpty.setText(R.string.status_nofiles);
+        filesList.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
+        filesAdapter = new FilesAdapter(context, new ArrayList<>());
+        filesList.setAdapter(filesAdapter);
+        filesList.setEmptyView(filesEmpty);
+        bindRefresh(pages[PAGE_FILES], refreshCallback);
+
+        // Peers page
+        pages[PAGE_PEERS] = inflater.inflate(R.layout.page_details_list, null);
+        peersList = pages[PAGE_PEERS].findViewById(R.id.page_list);
+        peersEmpty = pages[PAGE_PEERS].findViewById(R.id.page_empty);
+        peersEmpty.setText(R.string.status_nopeers);
+        peersAdapter = new PeersAdapter(context, geoIpHelper, new ArrayList<>());
+        peersList.setAdapter(peersAdapter);
+        peersList.setEmptyView(peersEmpty);
+        peersList.setFastScrollEnabled(true);
+        bindRefresh(pages[PAGE_PEERS], refreshCallback);
+
+        // Trackers page
+        pages[PAGE_TRACKERS] = inflater.inflate(R.layout.page_details_list, null);
+        trackersList = pages[PAGE_TRACKERS].findViewById(R.id.page_list);
+        TextView trackersEmpty = pages[PAGE_TRACKERS].findViewById(R.id.page_empty);
+        trackersEmpty.setText(R.string.status_notrackers);
+        trackersAdapter = new TrackersAdapter(context, new ArrayList<>());
+        trackersList.setAdapter(trackersAdapter);
+        trackersList.setEmptyView(trackersEmpty);
+        trackersList.setFastScrollEnabled(true);
+        bindRefresh(pages[PAGE_TRACKERS], refreshCallback);
+    }
+
+    private void bindRefresh(View page, Runnable refreshCallback) {
+        SwipeRefreshLayout swipe = page.findViewById(R.id.page_swipe);
+        swipe.setOnRefreshListener(() -> {
+            if (refreshCallback != null) {
+                refreshCallback.run();
+            }
+            swipe.setRefreshing(false); // We use our own loading indicator
+        });
+    }
+
+    /**
+     * The Files list view, exposed so the fragment can attach its multi-choice contextual action bar.
+     */
+    public ListView getFilesList() {
+        return filesList;
+    }
+
+    public void setFiles(List<TorrentFile> files) {
+        filesAdapter.update(files);
+    }
+
+    public void setPeers(List<Peer> peers, boolean supported) {
+        peersEmpty.setText(supported ? R.string.status_nopeers : R.string.status_peers_unsupported);
+        peersAdapter.update(supported ? peers : new ArrayList<>());
+    }
+
+    public void setTrackers(List<Tracker> trackers) {
+        trackersAdapter.update(trackers);
+    }
+
+    @NonNull
+    @Override
+    public PageViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View page = pages[viewType];
+        if (page.getParent() instanceof ViewGroup) {
+            ((ViewGroup) page.getParent()).removeView(page);
+        }
+        page.setLayoutParams(new RecyclerView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+        return new PageViewHolder(page);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PageViewHolder holder, int position) {
+        // Nothing to bind; pages are static and updated through the setX methods
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        // One distinct type per page so each pre-built page maps to a single holder
+        return position;
+    }
+
+    @Override
+    public int getItemCount() {
+        return PAGE_COUNT;
+    }
+
+    static class PageViewHolder extends RecyclerView.ViewHolder {
+        PageViewHolder(@NonNull View itemView) {
+            super(itemView);
+        }
+    }
+
+    /**
+     * Simple adapter that renders {@link TorrentFile} rows; mirrors the former inner adapter of
+     * {@link DetailsAdapter} so the Files page keeps the same look and multi-select behaviour.
+     */
+    private static class FilesAdapter extends BaseAdapter {
+
+        private final Context context;
+        private List<TorrentFile> items;
+
+        FilesAdapter(Context context, List<TorrentFile> items) {
+            this.context = context;
+            this.items = items;
+        }
+
+        void update(List<TorrentFile> newItems) {
+            this.items = newItems == null ? new ArrayList<>() : newItems;
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return items.size();
+        }
+
+        @Override
+        public TorrentFile getItem(int position) {
+            return items.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            TorrentFileView torrentFileView;
+            if (convertView == null) {
+                torrentFileView = TorrentFileView_.build(context);
+            } else {
+                torrentFileView = (TorrentFileView) convertView;
+            }
+            torrentFileView.bind(getItem(position));
+            return torrentFileView;
+        }
+
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/GeoIpHelper.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/GeoIpHelper.java
@@ -1,0 +1,245 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+import com.maxmind.db.Reader;
+import com.maxmind.db.Reader.FileMode;
+
+import org.androidannotations.annotations.EBean;
+import org.androidannotations.annotations.RootContext;
+import org.transdroid.daemon.Peer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Helper that manages an optional, locally downloaded GeoIP database (in MaxMind .mmdb format) used
+ * to resolve the country of a peer's IP address. When no database has been downloaded, callers
+ * should fall back to the country code provided by the torrent client (if any).
+ *
+ * <p>NOTE: the MaxMind reader 4.x requires Java 17, which is incompatible with this project's Java 8
+ * target; we use the last Java-8 compatible line (2.x), whose {@code Reader.get(InetAddress, Class)}
+ * decodes a record into a nested {@link Map} with a {@code country.iso_code} field (matching the
+ * ip66.dev schema).
+ */
+@EBean(scope = EBean.Scope.Singleton)
+public class GeoIpHelper {
+
+    public static final String DB_URL = "https://downloads.ip66.dev/db/ip66.mmdb";
+    private static final String DB_FILENAME = "ip66.mmdb";
+
+    @RootContext
+    protected Context context;
+
+    private Reader reader;
+    private boolean readerInitialised = false;
+
+    private File getDbFile() {
+        return new File(context.getFilesDir(), DB_FILENAME);
+    }
+
+    /**
+     * @return Whether a usable GeoIP database has been downloaded.
+     */
+    public boolean isDownloaded() {
+        File db = getDbFile();
+        return db.exists() && db.length() > 0;
+    }
+
+    /**
+     * Downloads the GeoIP database to the app's internal storage, replacing any existing copy. Runs
+     * synchronously; callers should invoke this off the UI thread.
+     *
+     * @throws IOException On any network or file error
+     */
+    public synchronized void download() throws IOException {
+        File target = getDbFile();
+        File temp = new File(context.getFilesDir(), DB_FILENAME + ".tmp");
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(DB_URL).openConnection();
+        connection.setConnectTimeout(15000);
+        connection.setReadTimeout(30000);
+        connection.setInstanceFollowRedirects(true);
+        try {
+            int status = connection.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new IOException("Unexpected HTTP response code " + status);
+            }
+            try (InputStream in = connection.getInputStream();
+                 OutputStream out = new FileOutputStream(temp)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                out.flush();
+            }
+            // Swap the freshly downloaded file into place
+            closeReader();
+            //noinspection ResultOfMethodCallIgnored
+            target.delete();
+            if (!temp.renameTo(target)) {
+                throw new IOException("Could not move the downloaded database into place");
+            }
+        } finally {
+            connection.disconnect();
+            //noinspection ResultOfMethodCallIgnored
+            temp.delete();
+        }
+    }
+
+    /**
+     * Deletes the downloaded GeoIP database; subsequent lookups fall back to client-provided data.
+     */
+    public synchronized void clear() {
+        closeReader();
+        //noinspection ResultOfMethodCallIgnored
+        getDbFile().delete();
+    }
+
+    private synchronized Reader getReader() {
+        if (!readerInitialised) {
+            readerInitialised = true;
+            if (isDownloaded()) {
+                try {
+                    // Use MEMORY (not MEMORY_MAPPED) to avoid java.nio.file.Path APIs (API 26+)
+                    reader = new Reader(getDbFile(), FileMode.MEMORY);
+                } catch (IOException e) {
+                    reader = null;
+                }
+            }
+        }
+        return reader;
+    }
+
+    private synchronized void closeReader() {
+        if (reader != null) {
+            try {
+                reader.close();
+            } catch (IOException ignored) {
+                // Ignore
+            }
+            reader = null;
+        }
+        readerInitialised = false;
+    }
+
+    /**
+     * Looks up the 2-letter ISO country code for the given IP (or host:port) string using the
+     * downloaded database, or null when unavailable.
+     */
+    @Nullable
+    public String lookupCountry(String address) {
+        Reader r = getReader();
+        if (r == null || address == null) {
+            return null;
+        }
+        try {
+            InetAddress ip = InetAddress.getByName(stripPort(address));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> record = r.get(ip, Map.class);
+            if (record == null) {
+                return null;
+            }
+            Object country = record.get("country");
+            if (!(country instanceof Map)) {
+                return null;
+            }
+            Object iso = ((Map<?, ?>) country).get("iso_code");
+            if (iso == null) {
+                return null;
+            }
+            String code = iso.toString();
+            return code.isEmpty() ? null : code.toUpperCase(Locale.US);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the country code for a peer, preferring the locally downloaded database (if present)
+     * and otherwise falling back to whatever the torrent client reported.
+     */
+    @Nullable
+    public String resolveCountry(Peer peer) {
+        if (isDownloaded()) {
+            String resolved = lookupCountry(peer.getAddress());
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+        return peer.getCountryCode();
+    }
+
+    /**
+     * Extracts the host part from a "host", "host:port" or "[ipv6]:port" address string.
+     */
+    private static String stripPort(String address) {
+        if (address == null) {
+            return null;
+        }
+        address = address.trim();
+        if (address.startsWith("[")) {
+            // [ipv6] or [ipv6]:port
+            int end = address.indexOf(']');
+            if (end > 0) {
+                return address.substring(1, end);
+            }
+            return address;
+        }
+        int colon = address.indexOf(':');
+        int lastColon = address.lastIndexOf(':');
+        if (colon >= 0 && colon == lastColon) {
+            // Exactly one colon: treat as host:port (IPv4 or hostname)
+            return address.substring(0, colon);
+        }
+        // No colon, or multiple colons (bare IPv6) -> use as-is
+        return address;
+    }
+
+    /**
+     * Converts a 2-letter ISO country code into the corresponding Unicode regional-indicator flag
+     * emoji (e.g. "US" -> 🇺🇸), or returns null for an invalid code.
+     */
+    @Nullable
+    public static String flagEmoji(String iso2) {
+        if (iso2 == null) {
+            return null;
+        }
+        String code = iso2.trim().toUpperCase(Locale.US);
+        if (code.length() != 2 || !code.matches("[A-Z]{2}")) {
+            return null;
+        }
+        int first = 0x1F1E6 + (code.charAt(0) - 'A');
+        int second = 0x1F1E6 + (code.charAt(1) - 'A');
+        return new String(Character.toChars(first)) + new String(Character.toChars(second));
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/PeerView.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/PeerView.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+
+import org.androidannotations.annotations.EViewGroup;
+import org.androidannotations.annotations.ViewById;
+import org.transdroid.R;
+import org.transdroid.daemon.Peer;
+import org.transdroid.daemon.util.FileSizeConverter;
+
+/**
+ * View that represents a single {@link Peer}, showing its client, address, country flag, transfer
+ * speeds and progress, with a left-edge bar indicating connection encryption.
+ *
+ * @author Eric Kok
+ */
+@EViewGroup(R.layout.list_item_peer)
+public class PeerView extends StatusBarLayout {
+
+    // Padlock shown after the address for an encrypted peer connection
+    private static final String PADLOCK = "🔒"; // 🔒
+
+    @ViewById
+    protected TextView clientText, addressText, progressText, speedsText;
+
+    public PeerView(Context context) {
+        super(context, null);
+    }
+
+    public void bind(Peer peer, GeoIpHelper geoIpHelper) {
+
+        clientText.setText(peer.getClient());
+
+        // Build the address line: optional country flag prefix, the address, and a padlock when encrypted
+        String country = geoIpHelper == null ? peer.getCountryCode() : geoIpHelper.resolveCountry(peer);
+        String flag = GeoIpHelper.flagEmoji(country);
+        StringBuilder address = new StringBuilder();
+        if (flag != null) {
+            address.append(flag).append(' ');
+        } else if (country != null && !country.isEmpty()) {
+            address.append(country).append(' ');
+        }
+        address.append(peer.getAddress());
+        Boolean encrypted = peer.isEncrypted();
+        if (encrypted != null && encrypted) {
+            address.append(' ').append(PADLOCK);
+        }
+        addressText.setText(address);
+
+        if (peer.getProgress() >= 0) {
+            progressText.setText(getResources().getString(R.string.status_percent, (int) (peer.getProgress() * 100)));
+            progressText.setVisibility(View.VISIBLE);
+        } else {
+            progressText.setVisibility(View.GONE);
+        }
+
+        speedsText.setText(getResources().getString(R.string.status_peer_speeds,
+                FileSizeConverter.getSize(peer.getDownSpeed()) + "/s",
+                FileSizeConverter.getSize(peer.getUpSpeed()) + "/s"));
+
+        // Left-edge bar reflects the peer's progress: green when it is a seed (100%), grey while it is
+        // still downloading, and hidden when the client does not report progress
+        float progress = peer.getProgress();
+        if (progress < 0) {
+            clearBarColor();
+        } else if (progress >= 1f) {
+            setBarColor(getResources().getColor(R.color.green));
+        } else {
+            setBarColor(getResources().getColor(R.color.grey));
+        }
+
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/PeersAdapter.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/PeersAdapter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+
+import org.transdroid.daemon.Peer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter that shows a list of {@link Peer} objects connected to a torrent.
+ *
+ * @author Eric Kok
+ */
+public class PeersAdapter extends BaseAdapter {
+
+    private final Context context;
+    private final GeoIpHelper geoIpHelper;
+    private List<Peer> items;
+
+    public PeersAdapter(Context context, GeoIpHelper geoIpHelper, List<Peer> items) {
+        this.context = context;
+        this.geoIpHelper = geoIpHelper;
+        this.items = items == null ? new ArrayList<>() : items;
+    }
+
+    /**
+     * Replaces all items in this adapter with the given new list of peers.
+     *
+     * @param newItems The new list of peers to display
+     */
+    public void update(List<Peer> newItems) {
+        this.items = newItems == null ? new ArrayList<>() : newItems;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getCount() {
+        return items.size();
+    }
+
+    @Override
+    public Peer getItem(int position) {
+        return items.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        PeerView peerView;
+        if (convertView == null) {
+            peerView = PeerView_.build(context);
+        } else {
+            peerView = (PeerView) convertView;
+        }
+        peerView.bind(getItem(position), geoIpHelper);
+        return peerView;
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/PiecesMapView.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/PiecesMapView.java
@@ -10,7 +10,7 @@ import org.transdroid.R;
 import java.util.ArrayList;
 import java.util.List;
 
-class PiecesMapView extends View {
+public class PiecesMapView extends View {
 
     private final float scale = getContext().getResources().getDisplayMetrics().density;
     private final int MINIMUM_HEIGHT = (int) (25 * scale);

--- a/app/src/main/java/org/transdroid/core/gui/lists/StatusBarLayout.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/StatusBarLayout.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.util.AttributeSet;
+import android.widget.RelativeLayout;
+
+import androidx.annotation.ColorInt;
+
+/**
+ * A relative layout that paints a coloured bar along its far-left edge, used to indicate a status
+ * (e.g. a peer's encryption or a tracker's connection state). This generalises the colour-bar drawing
+ * of {@link TorrentFilePriorityLayout} to an arbitrary colour.
+ *
+ * @author Eric Kok
+ */
+public class StatusBarLayout extends RelativeLayout {
+
+    private final float scale = getContext().getResources().getDisplayMetrics().density;
+    private final int WIDTH = (int) (6 * scale + 0.5f);
+    private final Paint barPaint = new Paint();
+    private final RectF fullRect = new RectF();
+    private boolean hasColor = false;
+
+    public StatusBarLayout(Context context) {
+        super(context);
+        setWillNotDraw(false);
+    }
+
+    public StatusBarLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setWillNotDraw(false);
+    }
+
+    /**
+     * Sets the colour of the left-edge status bar. Use {@link #clearBarColor()} to hide it.
+     *
+     * @param color The colour to paint
+     */
+    public void setBarColor(@ColorInt int color) {
+        this.hasColor = true;
+        this.barPaint.setColor(color);
+        this.invalidate();
+    }
+
+    public void clearBarColor() {
+        this.hasColor = false;
+        this.invalidate();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        if (!hasColor) {
+            return;
+        }
+        fullRect.set(0, 0, WIDTH, getHeight());
+        canvas.drawRect(fullRect, barPaint);
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/TrackerView.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/TrackerView.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.TextView;
+
+import org.androidannotations.annotations.EViewGroup;
+import org.androidannotations.annotations.ViewById;
+import org.transdroid.R;
+import org.transdroid.daemon.Tracker;
+
+/**
+ * View that represents a single {@link Tracker}, showing its URL and (optional) status message, with
+ * a left-edge bar coloured by the tracker's connection status.
+ *
+ * @author Eric Kok
+ */
+@EViewGroup(R.layout.list_item_tracker)
+public class TrackerView extends StatusBarLayout {
+
+    @ViewById
+    protected TextView urlText, messageText;
+
+    public TrackerView(Context context) {
+        super(context, null);
+    }
+
+    public void bind(Tracker tracker) {
+
+        urlText.setText(tracker.getUrl());
+
+        if (TextUtils.isEmpty(tracker.getMessage())) {
+            messageText.setVisibility(View.GONE);
+        } else {
+            messageText.setText(tracker.getMessage());
+            messageText.setVisibility(View.VISIBLE);
+        }
+
+        switch (tracker.getStatus()) {
+            case WORKING:
+                setBarColor(getResources().getColor(R.color.green));
+                break;
+            case ERROR:
+                setBarColor(getResources().getColor(R.color.red));
+                break;
+            case DISABLED:
+            case UNKNOWN:
+            default:
+                setBarColor(getResources().getColor(R.color.grey));
+                break;
+        }
+
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/lists/TrackersAdapter.java
+++ b/app/src/main/java/org/transdroid/core/gui/lists/TrackersAdapter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2024 Eric Kok et al.
+ *
+ * Transdroid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Transdroid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.core.gui.lists;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+
+import org.transdroid.daemon.Tracker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter that shows a list of {@link Tracker} objects with their connection status.
+ *
+ * @author Eric Kok
+ */
+public class TrackersAdapter extends BaseAdapter {
+
+    private final Context context;
+    private List<Tracker> items;
+
+    public TrackersAdapter(Context context, List<Tracker> items) {
+        this.context = context;
+        this.items = items == null ? new ArrayList<>() : items;
+    }
+
+    /**
+     * Replaces all items in this adapter with the given new list of trackers.
+     *
+     * @param newItems The new list of trackers to display
+     */
+    public void update(List<Tracker> newItems) {
+        this.items = newItems == null ? new ArrayList<>() : newItems;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getCount() {
+        return items.size();
+    }
+
+    @Override
+    public Tracker getItem(int position) {
+        return items.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        TrackerView trackerView;
+        if (convertView == null) {
+            trackerView = TrackerView_.build(context);
+        } else {
+            trackerView = (TrackerView) convertView;
+        }
+        trackerView.bind(getItem(position));
+        return trackerView;
+    }
+
+}

--- a/app/src/main/java/org/transdroid/core/gui/settings/SystemSettingsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/settings/SystemSettingsActivity.java
@@ -32,15 +32,18 @@ import androidx.preference.PreferenceManager;
 import com.nispok.snackbar.Snackbar;
 import com.nispok.snackbar.SnackbarManager;
 
+import org.androidannotations.annotations.Background;
 import org.androidannotations.annotations.Bean;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.OnActivityResult;
 import org.androidannotations.annotations.OptionsItem;
+import org.androidannotations.annotations.UiThread;
 import org.json.JSONException;
 import org.transdroid.R;
 import org.transdroid.core.app.settings.ApplicationSettings;
 import org.transdroid.core.app.settings.SettingsPersistence;
 import org.transdroid.core.gui.log.ErrorLogSender;
+import org.transdroid.core.gui.lists.GeoIpHelper;
 import org.transdroid.core.gui.navigation.NavigationHelper;
 import org.transdroid.core.gui.search.BarcodeHelper;
 import org.transdroid.core.gui.search.SearchHistoryProvider;
@@ -65,6 +68,20 @@ public class SystemSettingsActivity extends PreferenceCompatActivity {
     protected ErrorLogSender errorLogSender;
     @Bean
     protected SettingsPersistence settingsPersistence;
+    @Bean
+    protected GeoIpHelper geoIpHelper;
+
+    private OnPreferenceClickListener onGeoIpDownloadClick = preference -> {
+        SnackbarManager.show(Snackbar.with(SystemSettingsActivity.this).text(R.string.pref_geoip_downloading));
+        downloadGeoIpDatabase();
+        return true;
+    };
+    private OnPreferenceClickListener onGeoIpClearClick = preference -> {
+        geoIpHelper.clear();
+        updateGeoIpSummary();
+        SnackbarManager.show(Snackbar.with(SystemSettingsActivity.this).text(R.string.pref_geoip_clear_success));
+        return true;
+    };
 
     private OnPreferenceClickListener onImportSettingsClick = preference -> {
         showDialog(DIALOG_IMPORTSETTINGS);
@@ -133,8 +150,37 @@ public class SystemSettingsActivity extends PreferenceCompatActivity {
             getPreferenceScreen().removePreference(findPreference("system_checkupdates"));
         }
         findPreference("system_clearsearch").setOnPreferenceClickListener(onClearSearchClick);
+        findPreference("system_geoip_download").setOnPreferenceClickListener(onGeoIpDownloadClick);
+        findPreference("system_geoip_clear").setOnPreferenceClickListener(onGeoIpClearClick);
         findPreference("system_importsettings").setOnPreferenceClickListener(onImportSettingsClick);
         findPreference("system_exportsettings").setOnPreferenceClickListener(onExportSettingsClick);
+        updateGeoIpSummary();
+    }
+
+    private void updateGeoIpSummary() {
+        findPreference("system_geoip_download").setSummary(geoIpHelper.isDownloaded()
+                ? R.string.pref_geoip_download_info_downloaded : R.string.pref_geoip_download_info);
+    }
+
+    @Background
+    protected void downloadGeoIpDatabase() {
+        boolean success;
+        try {
+            geoIpHelper.download();
+            success = true;
+        } catch (IOException e) {
+            success = false;
+        }
+        onGeoIpDownloadComplete(success);
+    }
+
+    @UiThread
+    protected void onGeoIpDownloadComplete(boolean success) {
+        updateGeoIpSummary();
+        SnackbarManager.show(success
+                ? Snackbar.with(SystemSettingsActivity.this).text(R.string.pref_geoip_download_success)
+                : Snackbar.with(SystemSettingsActivity.this).text(R.string.pref_geoip_download_failed)
+                .colorResource(R.color.red));
     }
 
     @OptionsItem(android.R.id.home)

--- a/app/src/main/java/org/transdroid/daemon/Daemon.java
+++ b/app/src/main/java/org/transdroid/daemon/Daemon.java
@@ -427,6 +427,23 @@ public enum Daemon {
         return type == uTorrent || type == DelugeRpc || type == Deluge2Rpc;
     }
 
+    /**
+     * Whether the client exposes a per-torrent peer list (address, client, speeds, encryption, …).
+     */
+    public static boolean supportsExtraPeers(Daemon type) {
+        return type == qBittorrent || type == Transmission || type == Deluge || type == DelugeRpc || type == Deluge2Rpc
+                || type == rTorrent || type == uTorrent || type == BitTorrent || type == Dummy;
+    }
+
+    /**
+     * Whether the client itself reports a per-peer country code (used as a fallback when no local
+     * GeoIP database has been downloaded).
+     */
+    public static boolean supportsClientProvidedCountry(Daemon type) {
+        return type == qBittorrent || type == Deluge || type == DelugeRpc || type == Deluge2Rpc
+                || type == uTorrent || type == BitTorrent;
+    }
+
     public abstract IDaemonAdapter createAdapter(DaemonSettings settings);
 
 }

--- a/app/src/main/java/org/transdroid/daemon/DaemonMethod.java
+++ b/app/src/main/java/org/transdroid/daemon/DaemonMethod.java
@@ -46,7 +46,8 @@ public enum DaemonMethod {
     GetStats(21),
     ForceRecheck(22),
     ToggleSequentialDownload(23),
-    ToggleFirstLastPieceDownload(24);
+    ToggleFirstLastPieceDownload(24),
+    GetTorrentPeers(25);
 
     private static final Map<Integer, DaemonMethod> lookup = new HashMap<>();
 

--- a/app/src/main/java/org/transdroid/daemon/Peer.java
+++ b/app/src/main/java/org/transdroid/daemon/Peer.java
@@ -1,0 +1,135 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Represents a single peer connected to a torrent on a server daemon.
+ *
+ * @author erickok
+ */
+public final class Peer implements Parcelable {
+
+    public static final Parcelable.Creator<Peer> CREATOR = new Parcelable.Creator<Peer>() {
+        public Peer createFromParcel(Parcel in) {
+            return new Peer(in);
+        }
+
+        public Peer[] newArray(int size) {
+            return new Peer[size];
+        }
+    };
+
+    private final String address;
+    private final String client;
+    private final int downSpeed;
+    private final int upSpeed;
+    private final float progress;
+    private final Boolean isEncrypted;
+    private String countryCode;
+
+    public Peer(String address, String client, int downSpeed, int upSpeed, float progress, Boolean isEncrypted,
+                String countryCode) {
+        this.address = address;
+        this.client = client;
+        this.downSpeed = downSpeed;
+        this.upSpeed = upSpeed;
+        this.progress = progress;
+        this.isEncrypted = isEncrypted;
+        this.countryCode = countryCode;
+    }
+
+    private Peer(Parcel in) {
+        this.address = in.readString();
+        this.client = in.readString();
+        this.downSpeed = in.readInt();
+        this.upSpeed = in.readInt();
+        this.progress = in.readFloat();
+        // Nullable Boolean stored as int sentinel: -1 unknown, 0 false, 1 true
+        int enc = in.readInt();
+        this.isEncrypted = (enc == -1) ? null : (enc == 1);
+        this.countryCode = in.readString();
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public int getDownSpeed() {
+        return downSpeed;
+    }
+
+    public int getUpSpeed() {
+        return upSpeed;
+    }
+
+    /**
+     * The peer's download progress, in range [0,1].
+     *
+     * @return The fraction completed, or a negative number if unknown
+     */
+    public float getProgress() {
+        return progress;
+    }
+
+    /**
+     * Whether the connection to this peer is encrypted, or null if the client does not report it.
+     */
+    public Boolean isEncrypted() {
+        return isEncrypted;
+    }
+
+    /**
+     * The 2-letter ISO country code for this peer's IP, or null if unknown.
+     */
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    /**
+     * Overrides the country code, e.g. from a locally resolved GeoIP database.
+     *
+     * @param countryCode The 2-letter ISO country code to set
+     */
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(address);
+        dest.writeString(client);
+        dest.writeInt(downSpeed);
+        dest.writeInt(upSpeed);
+        dest.writeFloat(progress);
+        dest.writeInt(isEncrypted == null ? -1 : (isEncrypted ? 1 : 0));
+        dest.writeString(countryCode);
+    }
+
+}

--- a/app/src/main/java/org/transdroid/daemon/PeersSortBy.java
+++ b/app/src/main/java/org/transdroid/daemon/PeersSortBy.java
@@ -1,0 +1,155 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon;
+
+import java.util.Comparator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The criteria by which the GUI can sort a torrent's connected peers. The stored value matches the
+ * entryValues of the peer-sort preference.
+ *
+ * @author Eric Kok
+ */
+public enum PeersSortBy {
+
+    TotalSpeed("totalspeed"),
+    DownloadSpeed("downloadspeed"),
+    UploadSpeed("upspeed"),
+    Address("address"),
+    Client("client");
+
+    private final String value;
+
+    PeersSortBy(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static PeersSortBy fromValue(String value) {
+        for (PeersSortBy sortBy : values()) {
+            if (sortBy.value.equals(value)) {
+                return sortBy;
+            }
+        }
+        return TotalSpeed;
+    }
+
+    /**
+     * A comparator that orders peers according to this sort criterion. Speed-based sorts are
+     * descending (most active first); text-based sorts are ascending. Address is used as a stable
+     * tie-breaker so the list does not jump around between refreshes.
+     */
+    public Comparator<Peer> comparator() {
+        final Comparator<Peer> byAddress = (a, b) -> compareAddresses(a.getAddress(), b.getAddress());
+        switch (this) {
+            case DownloadSpeed:
+                return chain((a, b) -> Integer.compare(b.getDownSpeed(), a.getDownSpeed()), byAddress);
+            case UploadSpeed:
+                return chain((a, b) -> Integer.compare(b.getUpSpeed(), a.getUpSpeed()), byAddress);
+            case Address:
+                return byAddress;
+            case Client:
+                return chain((a, b) -> safe(a.getClient()).compareToIgnoreCase(safe(b.getClient())), byAddress);
+            case TotalSpeed:
+            default:
+                return chain((a, b) -> Long.compare((long) b.getDownSpeed() + b.getUpSpeed(),
+                        (long) a.getDownSpeed() + a.getUpSpeed()), byAddress);
+        }
+    }
+
+    private static Comparator<Peer> chain(final Comparator<Peer> primary, final Comparator<Peer> secondary) {
+        return (a, b) -> {
+            int result = primary.compare(a, b);
+            return result != 0 ? result : secondary.compare(a, b);
+        };
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static final Pattern IPV4 = Pattern.compile("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})");
+
+    /**
+     * Compares two peer addresses. IPv4 addresses are ordered numerically octet-by-octet (so
+     * 2.2.2.2 sorts before 111.1.1.1) and come before non-IPv4 addresses; anything else falls back
+     * to a case-insensitive string comparison.
+     */
+    static int compareAddresses(String a, String b) {
+        String hostA = host(a);
+        String hostB = host(b);
+        Long ipA = ipv4ToLong(hostA);
+        Long ipB = ipv4ToLong(hostB);
+        if (ipA != null && ipB != null) {
+            return Long.compare(ipA, ipB);
+        }
+        if (ipA != null) {
+            return -1; // IPv4 before IPv6/hostnames
+        }
+        if (ipB != null) {
+            return 1;
+        }
+        return hostA.compareToIgnoreCase(hostB);
+    }
+
+    /**
+     * Extracts the host part from a "host", "host:port" or "[ipv6]:port" address string.
+     */
+    private static String host(String address) {
+        if (address == null) {
+            return "";
+        }
+        address = address.trim();
+        if (address.startsWith("[")) {
+            int end = address.indexOf(']');
+            return end > 0 ? address.substring(1, end) : address;
+        }
+        int colon = address.indexOf(':');
+        if (colon >= 0 && colon == address.lastIndexOf(':')) {
+            // Exactly one colon: host:port (IPv4 or hostname)
+            return address.substring(0, colon);
+        }
+        // No colon, or multiple colons (bare IPv6): use as-is
+        return address;
+    }
+
+    /**
+     * Packs a dotted-quad IPv4 string into a long for numeric comparison, or null if not IPv4.
+     */
+    private static Long ipv4ToLong(String host) {
+        Matcher matcher = IPV4.matcher(host);
+        if (!matcher.matches()) {
+            return null;
+        }
+        long value = 0;
+        for (int i = 1; i <= 4; i++) {
+            int octet = Integer.parseInt(matcher.group(i));
+            if (octet > 255) {
+                return null;
+            }
+            value = (value << 8) | octet;
+        }
+        return value;
+    }
+
+}

--- a/app/src/main/java/org/transdroid/daemon/TorrentDetails.java
+++ b/app/src/main/java/org/transdroid/daemon/TorrentDetails.java
@@ -42,17 +42,22 @@ public final class TorrentDetails implements Parcelable {
     private final List<String> trackers;
     private final List<String> errors;
     private final List<Integer> pieces;
+    private final List<Tracker> trackerDetails;
 
     public TorrentDetails(List<String> trackers, List<String> errors) {
-        this.trackers = trackers;
-        this.errors = errors;
-        this.pieces = new ArrayList<>();
+        this(trackers, errors, new ArrayList<Integer>(), null);
     }
 
     public TorrentDetails(List<String> trackers, List<String> errors, List<Integer> pieces) {
+        this(trackers, errors, pieces, null);
+    }
+
+    public TorrentDetails(List<String> trackers, List<String> errors, List<Integer> pieces,
+                          List<Tracker> trackerDetails) {
         this.trackers = trackers;
         this.errors = errors;
-        this.pieces = pieces;
+        this.pieces = pieces == null ? new ArrayList<Integer>() : pieces;
+        this.trackerDetails = trackerDetails == null ? new ArrayList<Tracker>() : trackerDetails;
     }
 
     private TorrentDetails(Parcel in) {
@@ -64,6 +69,8 @@ public final class TorrentDetails implements Parcelable {
         for (int i : piecesarray) {
             this.pieces.add(i);
         }
+
+        this.trackerDetails = in.createTypedArrayList(Tracker.CREATOR);
     }
 
     public List<String> getTrackers() {
@@ -106,6 +113,17 @@ public final class TorrentDetails implements Parcelable {
         return this.pieces;
     }
 
+    /**
+     * The per-tracker details (URL, connection status and optional message). May be empty if the
+     * client/adapter does not provide structured tracker information; callers should fall back to
+     * {@link #getTrackers()} in that case.
+     *
+     * @return The list of trackers with status, never null
+     */
+    public List<Tracker> getTrackerDetails() {
+        return this.trackerDetails;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -123,6 +141,7 @@ public final class TorrentDetails implements Parcelable {
             }
         }
         dest.writeIntArray(piecesarray);
+        dest.writeTypedList(trackerDetails);
     }
 
 }

--- a/app/src/main/java/org/transdroid/daemon/Tracker.java
+++ b/app/src/main/java/org/transdroid/daemon/Tracker.java
@@ -1,0 +1,81 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Represents a single tracker of a torrent, together with its connection status and (optional)
+ * status/error message.
+ *
+ * @author erickok
+ */
+public final class Tracker implements Parcelable {
+
+    public static final Parcelable.Creator<Tracker> CREATOR = new Parcelable.Creator<Tracker>() {
+        public Tracker createFromParcel(Parcel in) {
+            return new Tracker(in);
+        }
+
+        public Tracker[] newArray(int size) {
+            return new Tracker[size];
+        }
+    };
+
+    private final String url;
+    private final TrackerStatus status;
+    private final String message;
+
+    public Tracker(String url, TrackerStatus status, String message) {
+        this.url = url;
+        this.status = status == null ? TrackerStatus.UNKNOWN : status;
+        this.message = message;
+    }
+
+    private Tracker(Parcel in) {
+        this.url = in.readString();
+        this.status = TrackerStatus.fromCode(in.readInt());
+        this.message = in.readString();
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public TrackerStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(url);
+        dest.writeInt(status.getCode());
+        dest.writeString(message);
+    }
+
+}

--- a/app/src/main/java/org/transdroid/daemon/TrackerStatus.java
+++ b/app/src/main/java/org/transdroid/daemon/TrackerStatus.java
@@ -1,0 +1,54 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon;
+
+/**
+ * The connection status of a tracker as reported by the server daemon. Used to render a coloured
+ * status marker next to each tracker in the GUI.
+ *
+ * @author erickok
+ */
+public enum TrackerStatus {
+    /** The tracker was contacted successfully. */
+    WORKING(0),
+    /** The tracker returned an error or could not be contacted. */
+    ERROR(1),
+    /** The tracker is disabled for this torrent. */
+    DISABLED(2),
+    /** The tracker status is not known (e.g. not yet announced, or the client does not report it). */
+    UNKNOWN(3);
+
+    private final int code;
+
+    TrackerStatus(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static TrackerStatus fromCode(int code) {
+        for (TrackerStatus status : values()) {
+            if (status.code == code) {
+                return status;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeAdapter.java
@@ -38,11 +38,14 @@ import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
 import org.transdroid.daemon.TorrentStatus;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -54,6 +57,8 @@ import org.transdroid.daemon.task.GetFileListTask;
 import org.transdroid.daemon.task.GetFileListTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.PauseTask;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.ResumeTask;
@@ -107,6 +112,14 @@ import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_METHOD_SETL
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_METHOD_SETTRACKERS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_METHOD_STATUS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NAME;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEERS;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEERS_FIELDS_ARRAY;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_CLIENT;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_COUNTRY;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_DOWNSPEED;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_IP;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_PROGRESS;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_UPSPEED;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NUMPEERS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NUMSEEDS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PARAMS;
@@ -239,6 +252,22 @@ public class DelugeAdapter implements IDaemonAdapter {
                     JSONObject dinfo = makeRequest(buildRequest(RPC_METHOD_STATUS, params), log);
                     return new GetTorrentDetailsTaskSuccessResult((GetTorrentDetailsTask) task, parseJsonTorrentDetails(dinfo.getJSONObject
                             (RPC_RESULT)));
+
+                case GetTorrentPeers:
+
+                    // Array of the fields needed for the peer listing
+                    JSONArray peerFields = new JSONArray();
+                    for (String field : RPC_PEERS_FIELDS_ARRAY) {
+                        peerFields.put(field);
+                    }
+
+                    // Request the peer listing of a torrent
+                    params.put(task.getTargetTorrent().getUniqueID()); // torrent_id
+                    params.put(peerFields); // keys
+
+                    JSONObject peerInfo = makeRequest(buildRequest(RPC_METHOD_STATUS, params), log);
+                    return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task,
+                            parseJsonPeers(peerInfo.getJSONObject(RPC_RESULT)));
 
                 case GetFileList:
 
@@ -714,17 +743,45 @@ public class DelugeAdapter implements IDaemonAdapter {
 
         // Parse response
         List<String> trackers = new ArrayList<>();
+        List<Tracker> trackerDetails = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+        // Deluge only exposes a single, global tracker status string (not per-tracker)
+        String trackerStatus = response.getString(RPC_TRACKER_STATUS);
+        errors.add(trackerStatus);
         JSONArray trackerObjects = response.getJSONArray(RPC_TRACKERS);
         if (trackerObjects != null && trackerObjects.length() > 0) {
             for (int i = 0; i < trackerObjects.length(); i++) {
-                trackers.add(trackerObjects.getJSONObject(i).getString("url"));
+                String url = trackerObjects.getJSONObject(i).getString("url");
+                trackers.add(url);
+                // Per-tracker status is unavailable; apply the global status as the (unknown) message
+                trackerDetails.add(new Tracker(url, TrackerStatus.UNKNOWN, trackerStatus));
             }
         }
-        List<String> errors = new ArrayList<>();
-        String trackerStatus = response.getString(RPC_TRACKER_STATUS);
-        errors.add(trackerStatus);
 
-        return new TorrentDetails(trackers, errors);
+        return new TorrentDetails(trackers, errors, null, trackerDetails);
+
+    }
+
+    private List<Peer> parseJsonPeers(JSONObject response) throws JSONException {
+
+        List<Peer> peerList = new ArrayList<>();
+        JSONArray peers = response.optJSONArray(RPC_PEERS);
+        if (peers != null) {
+            for (int i = 0; i < peers.length(); i++) {
+                JSONObject peer = peers.getJSONObject(i);
+                String country = peer.optString(RPC_PEER_COUNTRY);
+                if (country != null) {
+                    country = country.trim().toUpperCase(java.util.Locale.US);
+                    if (country.isEmpty()) {
+                        country = null;
+                    }
+                }
+                peerList.add(new Peer(peer.optString(RPC_PEER_IP), peer.optString(RPC_PEER_CLIENT),
+                        peer.optInt(RPC_PEER_DOWNSPEED), peer.optInt(RPC_PEER_UPSPEED),
+                        (float) peer.optDouble(RPC_PEER_PROGRESS, -1d), null, country));
+            }
+        }
+        return peerList;
 
     }
 

--- a/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeCommon.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeCommon.java
@@ -96,8 +96,16 @@ class DelugeCommon {
     static final String RPC_TRACKER_STATUS = "tracker_status";
     static final String RPC_URL = "url";
     static final String RPC_UPLOADEDEVER = "total_uploaded";
+    static final String RPC_PEERS = "peers";
+    static final String RPC_PEER_CLIENT = "client";
+    static final String RPC_PEER_COUNTRY = "country";
+    static final String RPC_PEER_DOWNSPEED = "down_speed";
+    static final String RPC_PEER_UPSPEED = "up_speed";
+    static final String RPC_PEER_IP = "ip";
+    static final String RPC_PEER_PROGRESS = "progress";
 
     static final String[] RPC_DETAILS_FIELDS_ARRAY = {RPC_TRACKERS, RPC_TRACKER_STATUS,};
+    static final String[] RPC_PEERS_FIELDS_ARRAY = {RPC_PEERS,};
     static final String[] RPC_FIELDS_ARRAY = {RPC_HASH, RPC_NAME, RPC_STATUS, RPC_SAVEPATH, RPC_RATEDOWNLOAD, RPC_RATEUPLOAD, RPC_NUMPEERS,
             RPC_NUMSEEDS, RPC_TOTALPEERS, RPC_TOTALSEEDS, RPC_ETA, RPC_DOWNLOADEDEVER, RPC_UPLOADEDEVER, RPC_TOTALSIZE, RPC_PARTDONE, RPC_LABEL,
             RPC_MESSAGE, RPC_TIMEADDED, RPC_TRACKER_STATUS,};

--- a/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeRpcAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/deluge/DelugeRpcAdapter.java
@@ -34,10 +34,13 @@ import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -50,6 +53,8 @@ import org.transdroid.daemon.task.GetFileListTask;
 import org.transdroid.daemon.task.GetFileListTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
@@ -119,6 +124,14 @@ import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_METHOD_STAT
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_MOVE_COMPLETED;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_MOVE_COMPLETED_PATH;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NAME;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEERS;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEERS_FIELDS_ARRAY;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_CLIENT;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_COUNTRY;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_DOWNSPEED;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_IP;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_PROGRESS;
+import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PEER_UPSPEED;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NUMPEERS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_NUMSEEDS;
 import static org.transdroid.daemon.adapters.deluge.DelugeCommon.RPC_PARTDONE;
@@ -195,6 +208,8 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
                     return doSetDownloadLocation(client, (SetDownloadLocationTask) task);
                 case GetTorrentDetails:
                     return doGetTorrentDetails(client, (GetTorrentDetailsTask) task);
+                case GetTorrentPeers:
+                    return doGetTorrentPeers(client, (GetTorrentPeersTask) task);
                 case SetTrackers:
                     return doSetTrackers(client, (SetTrackersTask) task);
                 case ForceRecheck:
@@ -336,14 +351,47 @@ public class DelugeRpcAdapter implements IDaemonAdapter, RemoteRssSupplier {
         //noinspection unchecked
         final List<Map<String, Object>> trackerResponses = (List<Map<String, Object>>) response.get(RPC_TRACKERS);
         final List<String> trackers = new ArrayList<>();
+        final List<Tracker> trackerDetails = new ArrayList<>();
+        final String trackerStatus = (String) response.get(RPC_TRACKER_STATUS);
         if (trackerResponses != null) {
             for (Map<String, Object> trackerResponse : trackerResponses) {
-                trackers.add((String) trackerResponse.get(RPC_URL));
+                final String url = (String) trackerResponse.get(RPC_URL);
+                trackers.add(url);
+                // Deluge only exposes a single, global tracker status string (not per-tracker)
+                trackerDetails.add(new Tracker(url, TrackerStatus.UNKNOWN, trackerStatus));
             }
         }
 
-        return new GetTorrentDetailsTaskSuccessResult(task, new TorrentDetails(trackers, Collections.singletonList((String) response.get
-                (RPC_TRACKER_STATUS))));
+        return new GetTorrentDetailsTaskSuccessResult(task, new TorrentDetails(trackers,
+                Collections.singletonList(trackerStatus), null, trackerDetails));
+    }
+
+    private GetTorrentPeersTaskSuccessResult doGetTorrentPeers(DelugeRpcClient client, GetTorrentPeersTask task) throws DaemonException {
+        //noinspection unchecked
+        final Map<String, Object> response = (Map<String, Object>) client.sendRequest(RPC_METHOD_STATUS,
+                task.getTargetTorrent().getUniqueID(), RPC_PEERS_FIELDS_ARRAY);
+
+        //noinspection unchecked
+        final List<Map<String, Object>> peerResponses = (List<Map<String, Object>>) response.get(RPC_PEERS);
+        final List<Peer> peers = new ArrayList<>();
+        if (peerResponses != null) {
+            for (Map<String, Object> peerResponse : peerResponses) {
+                final Number down = (Number) peerResponse.get(RPC_PEER_DOWNSPEED);
+                final Number up = (Number) peerResponse.get(RPC_PEER_UPSPEED);
+                final Number progress = (Number) peerResponse.get(RPC_PEER_PROGRESS);
+                String country = (String) peerResponse.get(RPC_PEER_COUNTRY);
+                if (country != null) {
+                    country = country.trim().toUpperCase(java.util.Locale.US);
+                    if (country.isEmpty()) {
+                        country = null;
+                    }
+                }
+                peers.add(new Peer((String) peerResponse.get(RPC_PEER_IP), (String) peerResponse.get(RPC_PEER_CLIENT),
+                        down == null ? 0 : down.intValue(), up == null ? 0 : up.intValue(),
+                        progress == null ? -1f : progress.floatValue(), null, country));
+            }
+        }
+        return new GetTorrentPeersTaskSuccessResult(task, peers);
     }
 
     private GetFileListTaskSuccessResult doGetFileList(DelugeRpcClient client, GetFileListTask task) throws DaemonException {

--- a/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/qBittorrent/QBittorrentAdapter.java
@@ -39,11 +39,14 @@ import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
 import org.transdroid.daemon.TorrentStatus;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -57,6 +60,8 @@ import org.transdroid.daemon.task.GetStatsTask;
 import org.transdroid.daemon.task.GetStatsTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
@@ -74,7 +79,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -287,6 +294,17 @@ public class QBittorrentAdapter implements IDaemonAdapter {
                     }
 
                     return new GetTorrentDetailsTaskSuccessResult((GetTorrentDetailsTask) task, parseJsonTorrentDetails(messages, pieces));
+
+                case GetTorrentPeers:
+
+                    // Request the connected peers for a specific torrent (only on the v2 API)
+                    String phash = task.getTargetTorrent().getUniqueID();
+                    if (version < 40100) {
+                        return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task, new ArrayList<Peer>());
+                    }
+                    JSONObject peersResult = new JSONObject(makeRequest(log, "/api/v2/sync/torrentPeers",
+                            new BasicNameValuePair("hash", phash), new BasicNameValuePair("rid", "0")));
+                    return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task, parseJsonPeers(peersResult));
 
                 case GetFileList:
 
@@ -685,15 +703,19 @@ public class QBittorrentAdapter implements IDaemonAdapter {
 
         ArrayList<String> trackers = new ArrayList<>();
         ArrayList<String> errors = new ArrayList<>();
+        ArrayList<Tracker> trackerDetails = new ArrayList<>();
 
         // Parse response
         if (messages.length() > 0) {
             for (int i = 0; i < messages.length(); i++) {
                 JSONObject tor = messages.getJSONObject(i);
-                trackers.add(tor.getString("url"));
-                String msg = tor.getString("msg");
+                String url = tor.getString("url");
+                trackers.add(url);
+                String msg = tor.optString("msg");
                 if (msg != null && !msg.equals(""))
                     errors.add(msg);
+                // qBittorrent v2 status: 0=disabled, 1=not contacted, 2=working, 3=updating, 4=not working
+                trackerDetails.add(new Tracker(url, qbTrackerStatus(tor.optInt("status", -1)), msg));
             }
         }
 
@@ -705,7 +727,54 @@ public class QBittorrentAdapter implements IDaemonAdapter {
         }
 
         // Return the list
-        return new TorrentDetails(trackers, errors, pieces);
+        return new TorrentDetails(trackers, errors, pieces, trackerDetails);
+
+    }
+
+    private TrackerStatus qbTrackerStatus(int status) {
+        switch (status) {
+            case 0:
+                return TrackerStatus.DISABLED;
+            case 2:
+                return TrackerStatus.WORKING;
+            case 4:
+                return TrackerStatus.ERROR;
+            case 1: // not contacted yet
+            case 3: // updating
+            default:
+                return TrackerStatus.UNKNOWN;
+        }
+    }
+
+    private List<Peer> parseJsonPeers(JSONObject response) throws JSONException {
+
+        List<Peer> peerList = new ArrayList<>();
+        JSONObject peers = response.optJSONObject("peers");
+        if (peers == null) {
+            return peerList;
+        }
+        for (Iterator<String> it = peers.keys(); it.hasNext(); ) {
+            String key = it.next();
+            JSONObject peer = peers.getJSONObject(key);
+            String address = peer.optString("ip");
+            int port = peer.optInt("port", 0);
+            if (port > 0) {
+                address = address + ":" + port;
+            }
+            String flags = peer.optString("flags");
+            Boolean encrypted = (flags == null || flags.isEmpty()) ? null
+                    : (flags.contains("E") || flags.contains("e"));
+            String country = peer.optString("country_code");
+            if (country != null) {
+                country = country.toUpperCase(Locale.US);
+                if (country.isEmpty()) {
+                    country = null;
+                }
+            }
+            peerList.add(new Peer(address, peer.optString("client"), peer.optInt("dl_speed"),
+                    peer.optInt("up_speed"), (float) peer.optDouble("progress", -1d), encrypted, country));
+        }
+        return peerList;
 
     }
 

--- a/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
@@ -29,10 +29,13 @@ import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
 import org.transdroid.daemon.Priority;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
 import org.transdroid.daemon.TorrentStatus;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -44,6 +47,8 @@ import org.transdroid.daemon.task.GetFileListTask;
 import org.transdroid.daemon.task.GetFileListTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
@@ -146,10 +151,30 @@ public class RTorrentAdapter implements IDaemonAdapter {
                     Object dresult = makeRtorrentCall(log, "t.multicall", new String[]{
                             task.getTargetTorrent().getUniqueID(),
                             "",
-                            "t.url="});
+                            "t.url=",
+                            "t.is_enabled=",
+                            "t.is_usable=",
+                            "t.success_counter=",
+                            "t.failed_counter="});
                     // @formatter:on
                     return new GetTorrentDetailsTaskSuccessResult((GetTorrentDetailsTask) task,
                             onTorrentDetailsRetrieved(log, dresult));
+
+                case GetTorrentPeers:
+
+                    // @formatter:off
+                    Object presult = makeRtorrentCall(log, "p.multicall", new String[]{
+                            task.getTargetTorrent().getUniqueID(),
+                            "",
+                            "p.address=",
+                            "p.client_version=",
+                            "p.down_rate=",
+                            "p.up_rate=",
+                            "p.is_encrypted=",
+                            "p.completed_percent="});
+                    // @formatter:on
+                    return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task,
+                            onTorrentPeersRetrieved(log, presult));
 
                 case GetFileList:
 
@@ -649,19 +674,82 @@ public class RTorrentAdapter implements IDaemonAdapter {
             // Parse a torrent's trackers from response
             // Formatted as Object[][], see http://libtorrent.rakshasa.no/wiki/RTorrentCommands#Download
             List<String> trackers = new ArrayList<>();
+            List<Tracker> trackerDetails = new ArrayList<>();
             Object[] responseList = (Object[]) response;
             try {
                 for (Object aResponseList : responseList) {
                     Object[] info = (Object[]) aResponseList;
-                    trackers.add((String) info[0]);
+                    String url = (String) info[0];
+                    trackers.add(url);
+                    // info: url, is_enabled, is_usable, success_counter, failed_counter
+                    TrackerStatus status = TrackerStatus.UNKNOWN;
+                    if (info.length >= 5) {
+                        long enabled = toLong(info[1]);
+                        long usable = toLong(info[2]);
+                        long success = toLong(info[3]);
+                        long failed = toLong(info[4]);
+                        if (enabled == 0) {
+                            status = TrackerStatus.DISABLED;
+                        } else if (usable == 1 && success > 0) {
+                            status = TrackerStatus.WORKING;
+                        } else if (failed > 0) {
+                            status = TrackerStatus.ERROR;
+                        }
+                    }
+                    trackerDetails.add(new Tracker(url, status, null));
                 }
             } catch (Exception e) {
                 log.e(LOG_NAME, e.toString());
             }
-            return new TorrentDetails(trackers, null);
+            return new TorrentDetails(trackers, null, null, trackerDetails);
 
         }
 
+    }
+
+    private List<Peer> onTorrentPeersRetrieved(Log log, Object response) throws DaemonException {
+
+        if (!(response instanceof Object[])) {
+            throw new DaemonException(ExceptionType.ParsingFailed,
+                    "Response on retrieving peers did not return a list of objects");
+        }
+
+        // Parse a torrent's peers from response, formatted as Object[][]
+        List<Peer> peers = new ArrayList<>();
+        Object[] responseList = (Object[]) response;
+        try {
+            for (Object aResponseList : responseList) {
+                Object[] info = (Object[]) aResponseList;
+                String address = (String) info[0];
+                String client = (String) info[1];
+                int down = (int) toLong(info[2]);
+                int up = (int) toLong(info[3]);
+                Boolean encrypted = info.length > 4 ? toLong(info[4]) == 1 : null;
+                float progress = info.length > 5 ? toLong(info[5]) / 100f : -1f;
+                peers.add(new Peer(address, client, down, up, progress, encrypted, null));
+            }
+        } catch (Exception e) {
+            log.e(LOG_NAME, e.toString());
+        }
+        return peers;
+
+    }
+
+    /**
+     * rTorrent returns either 32-bit Integer or (in the i8 dialect) 64-bit Long values; normalise to long.
+     */
+    private long toLong(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong(((String) value).trim());
+            } catch (NumberFormatException ignored) {
+                return 0;
+            }
+        }
+        return 0;
     }
 
     @Override

--- a/app/src/main/java/org/transdroid/daemon/adapters/transmission/TransmissionAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/transmission/TransmissionAdapter.java
@@ -33,11 +33,14 @@ import org.transdroid.daemon.DaemonException;
 import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
 import org.transdroid.daemon.TorrentFile;
 import org.transdroid.daemon.TorrentStatus;
+import org.transdroid.daemon.Tracker;
+import org.transdroid.daemon.TrackerStatus;
 import org.transdroid.daemon.task.AddByFileTask;
 import org.transdroid.daemon.task.AddByMagnetUrlTask;
 import org.transdroid.daemon.task.AddByUrlTask;
@@ -52,6 +55,8 @@ import org.transdroid.daemon.task.GetStatsTask;
 import org.transdroid.daemon.task.GetStatsTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.PauseTask;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.ResumeTask;
@@ -172,6 +177,18 @@ public class TransmissionAdapter implements IDaemonAdapter {
                     JSONObject getDResult = makeRequest(log, buildRequestObject("torrent-get", buildDGet));
                     return new GetTorrentDetailsTaskSuccessResult((GetTorrentDetailsTask) task,
                             parseJsonTorrentDetails(getDResult.getJSONObject("arguments")));
+
+                case GetTorrentPeers:
+
+                    // Request the connected peers of a specific torrent
+                    JSONArray pfields = new JSONArray();
+                    pfields.put("peers");
+                    JSONObject buildPGet =
+                            buildTorrentRequestObject(task.getTargetTorrent().getUniqueID(), null, false);
+                    buildPGet.put("fields", pfields);
+                    JSONObject getPResult = makeRequest(log, buildRequestObject("torrent-get", buildPGet));
+                    return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task,
+                            parseJsonPeers(getPResult.getJSONObject("arguments")));
 
                 case GetFileList:
 
@@ -648,17 +665,49 @@ public class TransmissionAdapter implements IDaemonAdapter {
             }
             JSONArray trackerStatsList = rarray.getJSONObject(0).getJSONArray("trackerStats");
             List<String> errors = new ArrayList<>();
+            List<Tracker> trackerDetails = new ArrayList<>();
             for (int i = 0; i < trackerStatsList.length(); i++) {
+                JSONObject stats = trackerStatsList.getJSONObject(i);
                 // Get the tracker response and if it was an error then add it
-                String lar = trackerStatsList.getJSONObject(i).getString("lastAnnounceResult");
+                String lar = stats.optString("lastAnnounceResult");
                 if (lar != null && !lar.equals("") && !lar.equals("Success")) {
                     errors.add(lar);
                 }
+                String url = stats.optString("announce", stats.optString("host"));
+                TrackerStatus status;
+                if (!stats.optBoolean("hasAnnounced", false)) {
+                    status = TrackerStatus.UNKNOWN;
+                } else if (stats.optBoolean("lastAnnounceSucceeded", false)) {
+                    status = TrackerStatus.WORKING;
+                } else {
+                    status = TrackerStatus.ERROR;
+                }
+                trackerDetails.add(new Tracker(url, status, lar));
             }
-            return new TorrentDetails(trackers, errors);
+            return new TorrentDetails(trackers, errors, null, trackerDetails);
         }
 
         return null;
+
+    }
+
+    private List<Peer> parseJsonPeers(JSONObject response) throws JSONException {
+
+        List<Peer> peerList = new ArrayList<>();
+        JSONArray rarray = response.getJSONArray("torrents");
+        if (rarray.length() > 0) {
+            JSONArray peers = rarray.getJSONObject(0).optJSONArray("peers");
+            if (peers != null) {
+                for (int i = 0; i < peers.length(); i++) {
+                    JSONObject peer = peers.getJSONObject(i);
+                    Boolean encrypted = peer.has("isEncrypted") ? peer.optBoolean("isEncrypted") : null;
+                    peerList.add(new Peer(peer.optString("address"), peer.optString("clientName"),
+                            peer.optInt("rateToClient"), peer.optInt("rateToPeer"),
+                            (float) peer.optDouble("progress", -1d), encrypted, null));
+                }
+            }
+        }
+        return peerList;
 
     }
 

--- a/app/src/main/java/org/transdroid/daemon/adapters/uTorrent/UTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/uTorrent/UTorrentAdapter.java
@@ -37,6 +37,7 @@ import org.transdroid.daemon.DaemonException.ExceptionType;
 import org.transdroid.daemon.DaemonSettings;
 import org.transdroid.daemon.IDaemonAdapter;
 import org.transdroid.daemon.Label;
+import org.transdroid.daemon.Peer;
 import org.transdroid.daemon.Priority;
 import org.transdroid.daemon.Torrent;
 import org.transdroid.daemon.TorrentDetails;
@@ -54,6 +55,8 @@ import org.transdroid.daemon.task.GetFileListTask;
 import org.transdroid.daemon.task.GetFileListTaskSuccessResult;
 import org.transdroid.daemon.task.GetTorrentDetailsTask;
 import org.transdroid.daemon.task.GetTorrentDetailsTaskSuccessResult;
+import org.transdroid.daemon.task.GetTorrentPeersTask;
+import org.transdroid.daemon.task.GetTorrentPeersTaskSuccessResult;
 import org.transdroid.daemon.task.RemoveTask;
 import org.transdroid.daemon.task.RetrieveTask;
 import org.transdroid.daemon.task.RetrieveTaskSuccessResult;
@@ -151,6 +154,14 @@ public class UTorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
                             "&action=getprops" + RPC_URL_HASH + task.getTargetTorrent().getUniqueID());
                     return new GetTorrentDetailsTaskSuccessResult((GetTorrentDetailsTask) task,
                             parseJsonTorrentDetails(dresult.getJSONArray("props")));
+
+                case GetTorrentPeers:
+
+                    // Request the connected peers of a specific torrent
+                    JSONObject presult = makeUtorrentRequest(log,
+                            "&action=getpeers" + RPC_URL_HASH + task.getTargetTorrent().getUniqueID());
+                    return new GetTorrentPeersTaskSuccessResult((GetTorrentPeersTask) task,
+                            parseJsonPeers(presult.getJSONArray("peers")));
 
                 case GetFileList:
 
@@ -594,6 +605,40 @@ public class UTorrentAdapter implements IDaemonAdapter, RemoteRssSupplier {
         }
 
         return null;
+
+    }
+
+    private List<Peer> parseJsonPeers(JSONArray results) throws JSONException {
+
+        // The getpeers response is [hash, [ [peer fields], ... ]] for the single requested torrent.
+        // Peer field indices follow the uTorrent Web UI constants.
+        List<Peer> peers = new ArrayList<>();
+        if (results.length() < 2) {
+            return peers;
+        }
+        JSONArray peerList = results.getJSONArray(1);
+        for (int i = 0; i < peerList.length(); i++) {
+            JSONArray peer = peerList.getJSONArray(i);
+            String country = peer.optString(0);
+            if (country != null) {
+                country = country.trim().toUpperCase(java.util.Locale.US);
+                if (country.isEmpty() || country.equals("00") || country.equals("XX")) {
+                    country = null;
+                }
+            }
+            String address = peer.optString(1);
+            int port = peer.optInt(4, 0);
+            if (port > 0) {
+                address = address + ":" + port;
+            }
+            String flags = peer.optString(6);
+            Boolean encrypted = (flags == null || flags.isEmpty()) ? null
+                    : (flags.contains("E") || flags.contains("e"));
+            float progress = peer.optInt(7, -1) / 1000f; // promille
+            peers.add(new Peer(address, peer.optString(5), peer.optInt(8), peer.optInt(9), progress, encrypted,
+                    country));
+        }
+        return peers;
 
     }
 

--- a/app/src/main/java/org/transdroid/daemon/task/GetTorrentPeersTask.java
+++ b/app/src/main/java/org/transdroid/daemon/task/GetTorrentPeersTask.java
@@ -1,0 +1,32 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon.task;
+
+import org.transdroid.daemon.DaemonMethod;
+import org.transdroid.daemon.IDaemonAdapter;
+import org.transdroid.daemon.Torrent;
+
+public class GetTorrentPeersTask extends DaemonTask {
+    protected GetTorrentPeersTask(IDaemonAdapter adapter, Torrent targetTorrent) {
+        super(adapter, DaemonMethod.GetTorrentPeers, targetTorrent, null);
+    }
+
+    public static GetTorrentPeersTask create(IDaemonAdapter adapter, Torrent targetTorrent) {
+        return new GetTorrentPeersTask(adapter, targetTorrent);
+    }
+}

--- a/app/src/main/java/org/transdroid/daemon/task/GetTorrentPeersTaskSuccessResult.java
+++ b/app/src/main/java/org/transdroid/daemon/task/GetTorrentPeersTaskSuccessResult.java
@@ -1,0 +1,42 @@
+/*
+ *	This file is part of Transdroid <http://www.transdroid.org>
+ *
+ *	Transdroid is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	Transdroid is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.transdroid.daemon.task;
+
+import org.transdroid.daemon.Peer;
+
+import java.util.List;
+
+/**
+ * The result of a successfully executed GetTorrentPeersTask on the daemon.
+ *
+ * @author erickok
+ */
+public class GetTorrentPeersTaskSuccessResult extends DaemonTaskSuccessResult {
+
+    private List<Peer> peers;
+
+    public GetTorrentPeersTaskSuccessResult(GetTorrentPeersTask executedTask, List<Peer> peers) {
+        super(executedTask);
+        this.peers = peers;
+    }
+
+    public List<Peer> getPeers() {
+        return peers;
+    }
+
+}

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -15,6 +15,7 @@
   along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/details_container"
     android:layout_width="match_parent"
@@ -39,22 +40,39 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipe_refresh_layout"
+    <RelativeLayout
+        android:id="@+id/details_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@id/details_menu">
+        android:layout_alignParentTop="true"
+        android:layout_above="@id/details_menu"
+        android:visibility="gone"
+        tools:visibility="visible">
 
-        <ListView
-            android:id="@+id/details_list"
+        <!-- Fixed summary header (TorrentDetailsView and pieces map are added in code) -->
+        <LinearLayout
+            android:id="@+id/details_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:orientation="vertical" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/details_tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/details_header"
+            app:tabGravity="fill"
+            app:tabMode="fixed" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/details_pager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:choiceMode="multipleChoiceModal"
-            android:divider="@null"
-            android:dividerHeight="0dip"
-            android:visibility="gone" />
+            android:layout_below="@id/details_tabs"
+            android:layout_alignParentBottom="true" />
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </RelativeLayout>
 
     <ProgressBar
         android:id="@+id/loading_progress"

--- a/app/src/main/res/layout/fragment_details_header.xml
+++ b/app/src/main/res/layout/fragment_details_header.xml
@@ -17,9 +17,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/margin_default"
-    android:layout_marginBottom="@dimen/margin_default">
+    android:layout_marginBottom="0dp">
 
     <LinearLayout
         android:id="@+id/date_label_wrapper"
@@ -199,12 +199,11 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/separator"
-        android:layout_marginBottom="@dimen/margin_half"
         android:orientation="vertical"
         android:paddingLeft="@dimen/margin_default"
         android:paddingTop="@dimen/margin_half"
         android:paddingRight="@dimen/margin_default"
-        android:paddingBottom="@dimen/margin_half">
+        android:paddingBottom="0dp">
 
         <TextView
             android:id="@+id/status_text"

--- a/app/src/main/res/layout/list_item_peer.xml
+++ b/app/src/main/res/layout/list_item_peer.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2010-2024 Eric Kok et al.
+
+  Transdroid is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Transdroid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<org.transdroid.core.gui.lists.StatusBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/margin_default"
+    android:paddingTop="@dimen/margin_half"
+    android:paddingRight="@dimen/margin_default"
+    android:paddingBottom="@dimen/margin_half">
+
+    <TextView
+        android:id="@+id/client_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@+id/progress_text"
+        android:layout_toLeftOf="@+id/progress_text"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textColor="?attr/text_bright"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_enlarged"
+        app:fontFamily="sans-serif-condensed"
+        tools:text="µTorrent 3.5.5" />
+
+    <TextView
+        android:id="@+id/progress_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_small"
+        tools:text="100%" />
+
+    <TextView
+        android:id="@+id/address_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/client_text"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@id/speeds_text"
+        android:layout_toLeftOf="@id/speeds_text"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_small"
+        tools:text="🇳🇱 192.168.1.20:51413 🔒" />
+
+    <TextView
+        android:id="@+id/speeds_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/progress_text"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_marginStart="@dimen/margin_half"
+        android:layout_marginLeft="@dimen/margin_half"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_small"
+        tools:text="▼ 1.2 MB/s  ▲ 30 KB/s" />
+
+</org.transdroid.core.gui.lists.StatusBarLayout>

--- a/app/src/main/res/layout/list_item_tracker.xml
+++ b/app/src/main/res/layout/list_item_tracker.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2010-2024 Eric Kok et al.
+
+  Transdroid is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Transdroid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<org.transdroid.core.gui.lists.StatusBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/margin_default"
+    android:paddingTop="@dimen/margin_half"
+    android:paddingRight="@dimen/margin_default"
+    android:paddingBottom="@dimen/margin_half">
+
+    <TextView
+        android:id="@+id/url_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/text_bright"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_default"
+        app:fontFamily="sans-serif-condensed"
+        tools:text="udp://tracker.example.org:1337/announce" />
+
+    <TextView
+        android:id="@+id/message_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/url_text"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/text_small"
+        android:visibility="gone"
+        tools:text="Working"
+        tools:visibility="visible" />
+
+</org.transdroid.core.gui.lists.StatusBarLayout>

--- a/app/src/main/res/layout/page_details_list.xml
+++ b/app/src/main/res/layout/page_details_list.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright 2010-2024 Eric Kok et al.
+
+  Transdroid is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Transdroid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/page_swipe"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ListView
+            android:id="@+id/page_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:divider="@null"
+            android:dividerHeight="0dip" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <TextView
+        android:id="@+id/page_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="@dimen/margin_default"
+        android:textIsSelectable="false"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,13 @@
     <string name="status_trackers">TRACKERS</string>
     <string name="status_errors">ERRORS</string>
     <string name="status_files">FILES</string>
+    <string name="status_peers">PEERS</string>
+    <string name="status_nofiles">No files</string>
+    <string name="status_nopeers">No connected peers</string>
+    <string name="status_notrackers">No trackers</string>
+    <string name="status_peers_unsupported">Peer listing is not supported by this client</string>
+    <string name="status_percent">%1$d%%</string>
+    <string name="status_peer_speeds">▼ %1$s  ▲ %2$s</string>
     <string name="status_maxspeed">Maximum transfer speeds</string>
     <string name="status_maxspeed_down">MAX DOWNLOAD</string>
     <string name="status_maxspeed_up">MAX UPLOAD</string>
@@ -330,6 +337,8 @@
     <string name="pref_system">System</string>
     <string name="pref_autorefresh">Automatic refreshing</string>
     <string name="pref_autorefresh_info">Interval-based refresh of the main screen</string>
+    <string name="pref_details_autorefresh">Automatic refreshing of details</string>
+    <string name="pref_details_autorefresh_info">Interval-based refresh while viewing a torrent\'s details</string>
     <string-array name="pref_autorefresh_intervals">
         <item>Disabled</item>
         <item>2 seconds</item>
@@ -344,6 +353,22 @@
         <item>10</item>
         <item>30</item>
     </string-array>
+    <string-array name="pref_peersort_entries">
+        <item>Total speed</item>
+        <item>Download speed</item>
+        <item>Upload speed</item>
+        <item>IP address</item>
+        <item>Torrent client</item>
+    </string-array>
+    <string-array name="pref_peersort_values" translatable="false">
+        <item>totalspeed</item>
+        <item>downloadspeed</item>
+        <item>upspeed</item>
+        <item>address</item>
+        <item>client</item>
+    </string-array>
+    <string name="pref_peersort">Sort peers by</string>
+    <string name="pref_peersort_info">Order of peers shown when viewing a torrent</string>
     <string name="pref_dormantasinactive">Treat dormant torrents as inactive</string>
     <string name="pref_dormantasinactive_info">Torrents at 0KB/s (no data transfer) will be filtered as being inactive</string>
     <string name="pref_checkupdates">Check for updates</string>
@@ -354,6 +379,15 @@
     <string name="pref_usedarktheme_info">Requires a restart to take effect</string>
     <string name="pref_clearsearch">Clear search history</string>
     <string name="pref_clearsearch_success">Search history is cleared</string>
+    <string name="pref_geoip_download">Download country database</string>
+    <string name="pref_geoip_download_info">Download an offline GeoIP database to show peer country flags for all clients</string>
+    <string name="pref_geoip_download_info_downloaded">Country database downloaded. Tap to re-download</string>
+    <string name="pref_geoip_downloading">Downloading country database…</string>
+    <string name="pref_geoip_download_success">Country database downloaded</string>
+    <string name="pref_geoip_download_failed">Could not download the country database</string>
+    <string name="pref_geoip_clear">Clear country database</string>
+    <string name="pref_geoip_clear_info">Remove the downloaded database and fall back to client-provided country data</string>
+    <string name="pref_geoip_clear_success">Country database removed</string>
     <string name="pref_import">Import settings</string>
     <string name="pref_import_dialog_android10">%1$s will try to import server, web search, RSS and system settings</string>
     <string name="pref_import_fromfile">Use file</string>

--- a/app/src/main/res/xml/pref_system.xml
+++ b/app/src/main/res/xml/pref_system.xml
@@ -33,6 +33,15 @@
         android:title="@string/pref_autorefresh"
         app:iconSpaceReserved="false" />
 
+    <ListPreference
+        android:defaultValue="0"
+        android:entries="@array/pref_autorefresh_intervals"
+        android:entryValues="@array/pref_autorefresh_intervalvalues"
+        android:key="details_autorefresh"
+        android:summary="@string/pref_details_autorefresh_info"
+        android:title="@string/pref_details_autorefresh"
+        app:iconSpaceReserved="false" />
+
     <CheckBoxPreference
         android:defaultValue="true"
         android:disableDependentsState="true"
@@ -49,6 +58,15 @@
         android:title="@string/pref_usedarktheme"
         app:iconSpaceReserved="false" />
 
+    <ListPreference
+        android:defaultValue="totalspeed"
+        android:entries="@array/pref_peersort_entries"
+        android:entryValues="@array/pref_peersort_values"
+        android:key="peer_sort"
+        android:title="@string/pref_peersort"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="system_checkupdates"
@@ -59,6 +77,18 @@
     <Preference
         android:key="system_clearsearch"
         android:title="@string/pref_clearsearch"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="system_geoip_download"
+        android:summary="@string/pref_geoip_download_info"
+        android:title="@string/pref_geoip_download"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="system_geoip_clear"
+        android:summary="@string/pref_geoip_clear_info"
+        android:title="@string/pref_geoip_clear"
         app:iconSpaceReserved="false" />
 
     <Preference


### PR DESCRIPTION
## Summary

This feature adds peer list support when viewing a torrent and other improvements to the tracker list, I've moved to a 3 tab system to tidy up the detail viewing of a torrent. It also reports the tracker status for each tracker and displays a colour relating to the status of a tracker. For peers the colour is whether the peer has 100% of the torrent or not.

Default view shows the files, then you can swipe to peers or trackers. I've also added auto refreshing support for torrent details, with the default being no auto refresh just like the normal main screen refresh.

Peers will also show a country flag, if the country is reported back from the torrent client, if your client doesn't support this there is a local geodatabase that will be used, if you've downloaded it in the system settings. For this I'm using https://ip66.dev since they provide free usage of their geodatabase.

You can change the default sort order of the peers, defaults to `Total speed` which is cumulative of both Download and Upload
- Total speed
- Download speed
- Upload speed
- IP address
- Torrent client

## Screenshots of the new view and settings
<img width="3474" height="4566" alt="image" src="https://github.com/user-attachments/assets/9d5f387f-a5db-406d-9906-e4a079145b44" />

## Devleopment
This change has been made using Claude, but I have tested and reviewed the code myself. It has been tested against Transmission and using Android 14 OnePlus 9.  I have reviewd the changes made to the code, java isn't a language I know that well.

Happy for this to be rejected if you do not want any AI assisted coding in this code base