### PR TITLE
Update priorities after set priorities on rTorrent

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/rTorrent/RTorrentAdapter.java
@@ -286,6 +286,9 @@ public class RTorrentAdapter implements IDaemonAdapter {
                                 new String[]{task.getTargetTorrent().getUniqueID() + ":f" + forFile.getKey(),
                                         newPriority});
                     }
+                    // Force rTorrent to re-evaluate its chunk selector so newly-disabled files actually stop
+                    // downloading (and newly-enabled files start); without this, pieces already queued keep going.
+                    makeRtorrentCall(log, "d.update_priorities", new String[]{task.getTargetTorrent().getUniqueID()});
                     return new DaemonTaskSuccessResult(task);
 
                 case SetTransferRates:


### PR DESCRIPTION
Call  update priorities after set priorities on rTorrent, so that disabled files stop downloading and newly-enabled ones start.

Fixes https://github.com/erickok/transdroid/issues/697
