### PR TITLE
Aria2c: fix remove and make clear does not support remove data

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsFragment.java
@@ -146,6 +146,7 @@ public class TorrentsFragment extends Fragment implements OnLabelPickedListener 
                 actionsMenu.getMenu().findItem(R.id.action_start).setVisible(Daemon.supportsStoppingStarting(daemonType));
                 actionsMenu.getMenu().findItem(R.id.action_stop).setVisible(Daemon.supportsStoppingStarting(daemonType));
                 actionsMenu.getMenu().findItem(R.id.action_setlabel).setVisible(Daemon.supportsSetLabel(daemonType));
+                actionsMenu.getMenu().findItem(R.id.action_remove_withdata).setVisible(Daemon.supportsRemoveWithData(daemonType));
             }
             // Pause autorefresh
             if (getActivity() != null && getActivity() instanceof TorrentsActivity) {

--- a/app/src/main/java/org/transdroid/daemon/Daemon.java
+++ b/app/src/main/java/org/transdroid/daemon/Daemon.java
@@ -369,7 +369,7 @@ public enum Daemon {
     public static boolean supportsRemoveWithData(Daemon type) {
         return type == uTorrent || type == Vuze || type == Transmission || type == Deluge || type == DelugeRpc || type == Deluge2Rpc
                 || type == BitTorrent || type == Tfb4rt || type == DLinkRouterBT || type == Bitflu || type == qBittorrent || type == BuffaloNas
-                || type == BitComet || type == rTorrent || type == Aria2 || type == tTorrent || type == Dummy;
+                || type == BitComet || type == rTorrent || type == tTorrent || type == Dummy;
     }
 
     public static boolean supportsFilePrioritySetting(Daemon type) {

--- a/app/src/main/java/org/transdroid/daemon/adapters/aria2c/Aria2Adapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/aria2c/Aria2Adapter.java
@@ -178,11 +178,12 @@ public class Aria2Adapter implements IDaemonAdapter {
 
                 case Remove:
 
-                    // Remove a torrent
+                    // Remove a torrent; batch stop + purge so it works in any state
                     RemoveTask removeTask = (RemoveTask) task;
-                    makeRequest(log,
-                            buildRequest(removeTask.includingData() ? "aria2.removeDownloadResult" : "aria2.remove",
-                                    params.put(removeTask.getTargetTorrent().getUniqueID())).toString());
+                    String removeGid = removeTask.getTargetTorrent().getUniqueID();
+                    JSONObject stopReq = buildRequest("aria2.remove", new JSONArray().put(removeGid));
+                    JSONObject purgeReq = buildRequest("aria2.removeDownloadResult", new JSONArray().put(removeGid));
+                    makeRequestForArray(log, new JSONArray().put(stopReq).put(purgeReq).toString());
                     return new DaemonTaskSuccessResult(task);
 
                 case Pause:


### PR DESCRIPTION
For Aria2c:

* fix remove to work on torrents in both active and stopped states
* remove from the list of clients that support remove data ([no remove data option in the rpc](https://aria2.github.io/manual/en/html/aria2c.html#json-rpc-over-websocket))

Also for multi select on the torrent list page, only show remove data when the client supports it so that it wont show that option on aria2c.

Fixes https://github.com/erickok/transdroid/issues/690
