### PR TITLE
Aria2c: calculate remaining time based on remaining length

### DIFF
--- a/app/src/main/java/org/transdroid/daemon/adapters/aria2c/Aria2Adapter.java
+++ b/app/src/main/java/org/transdroid/daemon/adapters/aria2c/Aria2Adapter.java
@@ -374,7 +374,7 @@ public class Aria2Adapter implements IDaemonAdapter {
                     numSeeders,
                     tor.getInt("connections"),
                     numSeeders,
-                    (downloadSpeed > 0 ? (int) (totalLength / downloadSpeed) : -1),
+                    (downloadSpeed > 0 ? (int) ((totalLength - completedLength) / downloadSpeed) : -1),
                     completedLength,
                     tor.getLong("uploadLength"),
                     totalLength,


### PR DESCRIPTION
On Aria2c, calculate the remaining time based on remaining length, not the total length.

Fixes https://github.com/erickok/transdroid/issues/574
