### PR TITLE
Add github ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build debug APKs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # PRs (including from forks) read the master-branch cache but never write it.
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Assemble, lint, and unit test (full + lite debug)
+        run: >
+          ./gradlew --no-daemon --stacktrace
+          assembleFullDebug assembleLiteDebug
+          lintFullDebug lintLiteDebug
+          testFullDebugUnitTest testLiteDebugUnitTest
+
+      - name: Upload debug APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: apks-${{ github.event.pull_request.number || github.sha }}
+          path: app/build/outputs/apk/**/debug/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload build reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ github.event.pull_request.number || github.sha }}
+          path: app/build/reports/**
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
Add github ci workflow that:

* checks out the source
* installs jdk 17
* sets up gradle and caching
* run the full and lite debug builds
* run Android Lint on both
* attempt to run tests
* uploads APKs with 14 day retention
* uploads reports on failure so you can see in the Checks tab

Fixes https://github.com/erickok/transdroid/issues/712
