### PR TITLE
Refresh torrent state in onResume

### DIFF
--- a/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
+++ b/app/src/main/java/org/transdroid/core/gui/TorrentsActivity.java
@@ -441,6 +441,10 @@ public class TorrentsActivity extends AppCompatActivity implements TorrentTasksE
             filterSelected(lastUsed, true);
         } else {
             currentConnection = lastUsed.getServerAdapter(connectivityHelper.getConnectedNetworkName(), this);
+            refreshTorrents();
+            if (Daemon.supportsStats(currentConnection.getType())) {
+                getAdditionalStats();
+            }
         }
 
         // Start auto refresh


### PR DESCRIPTION
Refresh the torrent state in onResume, so that you get a fresh listing even if you dont have auto refresh enabled.

Fixes https://github.com/erickok/transdroid/issues/633
